### PR TITLE
"Range" renamed to "WeaponRange" in FEH Wiki Weapons table

### DIFF
--- a/packages/fire-emblem-heroes-stats/build/index.js
+++ b/packages/fire-emblem-heroes-stats/build/index.js
@@ -509,7 +509,7 @@ async function fetchSkills() {
     format: 'json',
     limit: API_LIMIT,
     tables: 'Weapons',
-    fields: 'WeaponClass,WeaponName,Range,Cost,Effect,Might,Exclusive',
+    fields: 'WeaponClass,WeaponName,WeaponRange,Cost,Effect,Might,Exclusive',
     group_by: 'WeaponName',
   })
     .then(
@@ -522,13 +522,13 @@ async function fetchSkills() {
             Effect,
             Exclusive,
             Might,
-            Range,
+            WeaponRange,
             WeaponClass,
           }) => ({
             name: WeaponName,
             spCost: Number.parseInt(Cost, 10),
             'damage(mt)': Number.parseInt(Might, 10),
-            'range(rng)': Number.parseInt(Range, 10),
+            'range(rng)': Number.parseInt(WeaponRange, 10),
             effect: sanitizeDescription(Effect),
             'exclusive?': Number.parseInt(Exclusive, 10) === 1 ? 'Yes' : 'No',
             type: 'WEAPON',
@@ -548,8 +548,8 @@ async function fetchSkills() {
     limit: API_LIMIT,
     tables: 'Assists',
     fields:
-      '_pageName=Name,Cost,Effect,Range,WeaponRestriction,MovementRestriction,PrerequisiteSkill,Exclusive,SkillTier,SkillBuildCost',
-    group_by: '_pageName',
+      'Name,Cost,Effect,Range,WeaponRestriction,MovementRestriction,PrerequisiteSkill,Exclusive,SkillTier,SkillBuildCost',
+    group_by: 'Name',
   })
     .then(
       compose(


### PR DESCRIPTION
Thank you @ajhyndman for this very useful package (fire-emblem-heroes-stats)! I've been using it to generate the data source for a TypeScript Discord bot that I wrote so that my small friend group can check IVs and skill effects quickly with up-to-date information.

When scraping stats today with the `scrape-stats` script, I noticed that all weapons were showing up as unknown skills for heroes. Looking at [https://feheroes.gamepedia.com/Special:CargoTables/Weapons](https://feheroes.gamepedia.com/Special:CargoTables/Weapons), it appears the "Range" column was renamed to "WeaponRange". This pull request should resolve the issue with scraping weapon information.

This also includes a possible fix for dual rally skills (e.g. Rally Spd/Def) showing up as unknown skills ("Warning: Oscar has unknown skill: Rally Spd/Def").