### PR TITLE
Fix Cargo table join queries and normalize dates to ISO 8601 format

### DIFF
--- a/packages/fire-emblem-heroes-stats/build/index.js
+++ b/packages/fire-emblem-heroes-stats/build/index.js
@@ -627,9 +627,9 @@ async function fetchSkills() {
     limit: API_LIMIT,
     tables: 'PassiveGroup,PassiveSingle',
     fields:
-      'Name,Effect,SkillTier,SPCost,PassiveGroup.MovementRestriction=MovementRestriction,PassiveGroup.WeaponRestriction=WeaponRestriction,PassiveGroup.Exclusive=Exclusive,PassiveGroup.Ptype=Ptype',
+      'PassiveSingle.Name=Name,Effect,SkillTier,SPCost,PassiveGroup.MovementRestriction=MovementRestriction,PassiveGroup.WeaponRestriction=WeaponRestriction,PassiveGroup.Exclusive=Exclusive,PassiveGroup.Ptype=Ptype',
     join_on: 'PassiveGroup._pageName = PassiveSingle._pageName',
-    group_by: 'PassiveSingle.Name',
+    group_by: 'Name',
   })
     .then(
       compose(
@@ -673,10 +673,10 @@ async function fetchSkills() {
     limit: API_LIMIT,
     tables: 'PassiveGroup,PassiveSingle',
     fields:
-      'Name,Effect,SkillTier,PassiveGroup.Seal=Seal,PassiveGroup.MovementRestriction=MovementRestriction,PassiveGroup.WeaponRestriction=WeaponRestriction',
+      'PassiveSingle.Name=Name,Effect,SkillTier,PassiveGroup.Seal=Seal,PassiveGroup.MovementRestriction=MovementRestriction,PassiveGroup.WeaponRestriction=WeaponRestriction',
     where: 'PassiveGroup.Seal="1"',
     join_on: 'PassiveGroup._pageName = PassiveSingle._pageName',
-    group_by: 'PassiveSingle.Name',
+    group_by: 'Name',
   })
     .then(
       compose(

--- a/packages/fire-emblem-heroes-stats/build/index.js
+++ b/packages/fire-emblem-heroes-stats/build/index.js
@@ -298,12 +298,7 @@ async function fetchHeroStats() {
 
             // Convert release dates into expected format.
             const formatDate = timestamp =>
-              new Date(timestamp).toLocaleDateString('en-NA', {
-                timeZone: 'UTC',
-                month: 'short',
-                day: '2-digit',
-                year: 'numeric',
-              });
+              new Date(timestamp).toISOString().substring(0, 10);
 
             const releaseDate = ReleaseDate ? formatDate(ReleaseDate) : 'N/A';
 

--- a/packages/fire-emblem-heroes-stats/stats.json
+++ b/packages/fire-emblem-heroes-stats/stats.json
@@ -7,8 +7,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Abel.png",
@@ -154,7 +154,7 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "2",
-      "releaseDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -369,8 +369,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Apr 14, 2017",
-      "poolDate": "Apr 26, 2017",
+      "releaseDate": "2017-04-14",
+      "poolDate": "2017-04-26",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Alm.png",
@@ -482,8 +482,8 @@
       "weaponType": "Green Axe",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Aug 15, 2017",
-      "poolDate": "Aug 31, 2017",
+      "releaseDate": "2017-08-15",
+      "poolDate": "2017-08-31",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Amelia.png",
@@ -595,7 +595,7 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "2",
-      "releaseDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -810,7 +810,7 @@
       "weaponType": "Red Sword",
       "moveType": "Armored",
       "rarities": "4-5",
-      "releaseDate": "Oct 23, 2017",
+      "releaseDate": "2017-10-23",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -949,8 +949,8 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Arthur.png",
@@ -1125,7 +1125,7 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Oct 18, 2017",
+      "releaseDate": "2017-10-18",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -1298,8 +1298,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Jun 14, 2017",
-      "poolDate": "Jun 30, 2017",
+      "releaseDate": "2017-06-14",
+      "poolDate": "2017-06-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Athena.png",
@@ -1445,8 +1445,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Oct 19, 2017",
-      "poolDate": "Oct 30, 2017",
+      "releaseDate": "2017-10-19",
+      "poolDate": "2017-10-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Ayra.png",
@@ -1563,8 +1563,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Azama.png",
@@ -1742,8 +1742,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Azura.png",
@@ -1850,7 +1850,7 @@
       "weaponType": "Green Axe",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Dec 31, 2017",
+      "releaseDate": "2017-12-31",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -1959,7 +1959,7 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Sep 29, 2017",
+      "releaseDate": "2017-09-29",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -2068,8 +2068,8 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Barst.png",
@@ -2236,8 +2236,8 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Bartre.png",
@@ -2412,7 +2412,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "Jul 18, 2017",
+      "releaseDate": "2017-07-18",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -2593,8 +2593,8 @@
       "weaponType": "Green Axe",
       "moveType": "Flying",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Beruka.png",
@@ -2766,7 +2766,7 @@
       "weaponType": "Red Sword",
       "moveType": "Armored",
       "rarities": "4-5",
-      "releaseDate": "Sep 23, 2017",
+      "releaseDate": "2017-09-23",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -2918,8 +2918,8 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "May 15, 2017",
-      "poolDate": "May 30, 2017",
+      "releaseDate": "2017-05-15",
+      "poolDate": "2017-05-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Boey.png",
@@ -3108,8 +3108,8 @@
       "weaponType": "Red Sword",
       "moveType": "Flying",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Caeda.png",
@@ -3250,7 +3250,7 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "May 30, 2017",
+      "releaseDate": "2017-05-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -3295,11 +3295,11 @@
           "rarity": "-"
         },
         {
-          "name": "Attack Res 1",
+          "name": "Attack/Res 1",
           "rarity": "-"
         },
         {
-          "name": "Attack Res 2",
+          "name": "Attack/Res 2",
           "rarity": 5
         },
         {
@@ -3364,8 +3364,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Cain.png",
@@ -3511,8 +3511,8 @@
       "weaponType": "Green Axe",
       "moveType": "Flying",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Camilla.png",
@@ -3658,7 +3658,7 @@
       "weaponType": "Red Sword",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Dec 31, 2017",
+      "releaseDate": "2017-12-31",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -3699,15 +3699,15 @@
           "rarity": 5
         },
         {
-          "name": "Spd Def Bond 1",
+          "name": "Spd/Def Bond 1",
           "rarity": "-"
         },
         {
-          "name": "Spd Def Bond 2",
+          "name": "Spd/Def Bond 2",
           "rarity": "-"
         },
         {
-          "name": "Spd Def Bond 3",
+          "name": "Spd/Def Bond 3",
           "rarity": 5
         },
         {
@@ -3772,7 +3772,7 @@
       "weaponType": "Green Tome",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -3873,7 +3873,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "Jun 02, 2017",
+      "releaseDate": "2017-06-02",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -4046,8 +4046,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "3-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Catria.png",
@@ -4227,8 +4227,8 @@
       "weaponType": "Green Tome",
       "moveType": "Cavalry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Cecilia.png",
@@ -4471,8 +4471,8 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "May 15, 2017",
-      "poolDate": "May 30, 2017",
+      "releaseDate": "2017-05-15",
+      "poolDate": "2017-05-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Celica.png",
@@ -4584,8 +4584,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 22, 2018",
-      "poolDate": "Mar 09, 2018",
+      "releaseDate": "2018-02-22",
+      "poolDate": "2018-03-09",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Celica (Fallen Heroes).png",
@@ -4698,7 +4698,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "May 30, 2017",
+      "releaseDate": "2017-05-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -4807,8 +4807,8 @@
       "weaponType": "Green Axe",
       "moveType": "Flying",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Cherche.png",
@@ -4983,8 +4983,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Chrom.png",
@@ -5135,7 +5135,7 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -5175,11 +5175,11 @@
           "rarity": "-"
         },
         {
-          "name": "Attack Def +1",
+          "name": "Attack/Def +1",
           "rarity": "-"
         },
         {
-          "name": "Attack Def +2",
+          "name": "Attack/Def +2",
           "rarity": 5
         },
         {
@@ -5244,7 +5244,7 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Mar 09, 2018",
+      "releaseDate": "2018-03-09",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -5375,7 +5375,7 @@
       "weaponType": "Green Axe",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Dec 18, 2017",
+      "releaseDate": "2017-12-18",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -5411,15 +5411,15 @@
           "rarity": "-"
         },
         {
-          "name": "Brazen Atk Def 1",
+          "name": "Brazen Atk/Def 1",
           "rarity": "-"
         },
         {
-          "name": "Brazen Atk Def 2",
+          "name": "Brazen Atk/Def 2",
           "rarity": "-"
         },
         {
-          "name": "Brazen Atk Def 3",
+          "name": "Brazen Atk/Def 3",
           "rarity": 5
         },
         {
@@ -5484,8 +5484,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "4-5",
-      "releaseDate": "Apr 14, 2017",
-      "poolDate": "Apr 26, 2017",
+      "releaseDate": "2017-04-14",
+      "poolDate": "2017-04-26",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Clair.png",
@@ -5618,8 +5618,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Clarine.png",
@@ -5797,7 +5797,7 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Jun 28, 2017",
+      "releaseDate": "2017-06-28",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -5978,7 +5978,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Aug 11, 2017",
+      "releaseDate": "2017-08-11",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -6117,8 +6117,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Cordelia.png",
@@ -6269,7 +6269,7 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "May 30, 2017",
+      "releaseDate": "2017-05-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -6383,8 +6383,8 @@
       "weaponType": "Blue Breath",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Corrin (F).png",
@@ -6565,7 +6565,7 @@
       "weaponType": "Blue Tome",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-28",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -6679,8 +6679,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Corrin (M).png",
@@ -6827,7 +6827,7 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Jan 16, 2018",
+      "releaseDate": "2018-01-16",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -6872,11 +6872,11 @@
           "rarity": "-"
         },
         {
-          "name": "Attack Def +1",
+          "name": "Attack/Def +1",
           "rarity": 4
         },
         {
-          "name": "Attack Def +2",
+          "name": "Attack/Def +2",
           "rarity": 5
         },
         {
@@ -6884,11 +6884,11 @@
           "rarity": "-"
         },
         {
-          "name": "Spur Def Res 1",
+          "name": "Spur Def/Res 1",
           "rarity": "-"
         },
         {
-          "name": "Spur Def Res 2",
+          "name": "Spur Def/Res 2",
           "rarity": 4
         }
       ],
@@ -6975,8 +6975,8 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Oct 16, 2017",
-      "poolDate": "Oct 30, 2017",
+      "releaseDate": "2017-10-16",
+      "poolDate": "2017-10-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Deirdre.png",
@@ -7083,8 +7083,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jul 13, 2017",
-      "poolDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-13",
+      "poolDate": "2017-07-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Delthea.png",
@@ -7191,8 +7191,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Donnel.png",
@@ -7218,7 +7218,7 @@
         },
         {
           "name": "Brave Lance+",
-          "default": "-",
+          "default": 5,
           "rarity": 5
         },
         {
@@ -7427,8 +7427,8 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Nov 15, 2017",
-      "poolDate": "Nov 28, 2017",
+      "releaseDate": "2017-11-15",
+      "poolDate": "2017-11-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Dorcas.png",
@@ -7552,8 +7552,8 @@
       "weaponType": "Red Sword",
       "moveType": "Armored",
       "rarities": "2-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Draug.png",
@@ -7759,8 +7759,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Armored",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Effie.png",
@@ -7901,8 +7901,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 15, 2017",
-      "poolDate": "Feb 27, 2017",
+      "releaseDate": "2017-02-15",
+      "poolDate": "2017-02-27",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Eirika.png",
@@ -8035,8 +8035,8 @@
       "weaponType": "Red Tome",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Jan 25, 2018",
-      "poolDate": "Feb 09, 2018",
+      "releaseDate": "2018-01-25",
+      "poolDate": "2018-02-09",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Eirika (Sacred Memories).png",
@@ -8161,8 +8161,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Feb 27, 2017",
-      "poolDate": "Mar 14, 2017",
+      "releaseDate": "2017-02-27",
+      "poolDate": "2017-03-14",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Eldigan.png",
@@ -8266,8 +8266,8 @@
       "weaponType": "Red Sword",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Sep 15, 2017",
-      "poolDate": "Sep 29, 2017",
+      "releaseDate": "2017-09-15",
+      "poolDate": "2017-09-29",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Elincia.png",
@@ -8374,8 +8374,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Elise.png",
@@ -8485,7 +8485,7 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-28",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -8530,11 +8530,11 @@
           "rarity": "-"
         },
         {
-          "name": "Spd Res 1",
+          "name": "Spd/Res 1",
           "rarity": "-"
         },
         {
-          "name": "Spd Res 2",
+          "name": "Spd/Res 2",
           "rarity": 5
         },
         {
@@ -8599,8 +8599,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Eliwood.png",
@@ -8780,7 +8780,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Armored",
       "rarities": "4-5",
-      "releaseDate": "Feb 14, 2018",
+      "releaseDate": "2018-02-14",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -8928,8 +8928,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 15, 2017",
-      "poolDate": "Feb 27, 2017",
+      "releaseDate": "2017-02-15",
+      "poolDate": "2017-02-27",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Ephraim.png",
@@ -9041,7 +9041,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Feb 28, 2018",
+      "releaseDate": "2018-02-28",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -9159,8 +9159,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Est.png",
@@ -9335,8 +9335,8 @@
       "weaponType": "Green Breath",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Fae.png",
@@ -9477,8 +9477,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Apr 14, 2017",
-      "poolDate": "Apr 26, 2017",
+      "releaseDate": "2017-04-14",
+      "poolDate": "2017-04-26",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Faye.png",
@@ -9590,8 +9590,8 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Felicia.png",
@@ -9839,8 +9839,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Fir.png",
@@ -10020,7 +10020,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Nov 28, 2017",
+      "releaseDate": "2017-11-28",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -10066,15 +10066,15 @@
           "rarity": 5
         },
         {
-          "name": "Atk Def Bond 1",
+          "name": "Atk/Def Bond 1",
           "rarity": "-"
         },
         {
-          "name": "Atk Def Bond 2",
+          "name": "Atk/Def Bond 2",
           "rarity": "-"
         },
         {
-          "name": "Atk Def Bond 3",
+          "name": "Atk/Def Bond 3",
           "rarity": 5
         },
         {
@@ -10150,8 +10150,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Florina.png",
@@ -10326,8 +10326,8 @@
       "weaponType": "Green Axe",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Frederick.png",
@@ -10507,7 +10507,7 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jun 30, 2017",
+      "releaseDate": "2017-06-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -10559,11 +10559,11 @@
           "rarity": "-"
         },
         {
-          "name": "Seal Atk Spd 1",
+          "name": "Seal Atk/Spd 1",
           "rarity": "-"
         },
         {
-          "name": "Seal Atk Spd 2",
+          "name": "Seal Atk/Spd 2",
           "rarity": 5
         }
       ],
@@ -10616,8 +10616,8 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Gaius.png",
@@ -10792,7 +10792,7 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jun 30, 2017",
+      "releaseDate": "2017-06-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -10906,8 +10906,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "May 15, 2017",
-      "poolDate": "May 30, 2017",
+      "releaseDate": "2017-05-15",
+      "poolDate": "2017-05-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Genny.png",
@@ -11156,8 +11156,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Gordin.png",
@@ -11332,8 +11332,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jul 13, 2017",
-      "poolDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-13",
+      "poolDate": "2017-07-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Gray.png",
@@ -11440,7 +11440,7 @@
       "weaponType": "Green Tome",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Dec 28, 2017",
+      "releaseDate": "2017-12-28",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -11557,8 +11557,8 @@
       "weaponType": "Green Axe",
       "moveType": "Cavalry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Gunter.png",
@@ -11801,8 +11801,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Armored",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Gwendolyn.png",
@@ -11974,8 +11974,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Hana.png",
@@ -12218,8 +12218,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Feb 22, 2018",
-      "poolDate": "Mar 09, 2018",
+      "releaseDate": "2018-02-22",
+      "poolDate": "2018-03-09",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Hardin (Fallen Heroes).png",
@@ -12259,15 +12259,15 @@
           "rarity": 5
         },
         {
-          "name": "Brazen Def Res 1",
+          "name": "Brazen Def/Res 1",
           "rarity": "-"
         },
         {
-          "name": "Brazen Def Res 2",
+          "name": "Brazen Def/Res 2",
           "rarity": "-"
         },
         {
-          "name": "Brazen Def Res 3",
+          "name": "Brazen Def/Res 3",
           "rarity": 5
         },
         {
@@ -12332,8 +12332,8 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Hawkeye.png",
@@ -12479,8 +12479,8 @@
       "weaponType": "Green Axe",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Hector.png",
@@ -12584,7 +12584,7 @@
       "weaponType": "Green Axe",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Feb 09, 2018",
+      "releaseDate": "2018-02-09",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -12690,8 +12690,8 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Henry.png",
@@ -12871,7 +12871,7 @@
       "weaponType": "Green Tome",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Oct 30, 2017",
+      "releaseDate": "2017-10-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -12977,8 +12977,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Hinata.png",
@@ -13158,8 +13158,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Hinoka.png",
@@ -13271,8 +13271,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Apr 26, 2017",
-      "poolDate": "May 15, 2017",
+      "releaseDate": "2017-04-26",
+      "poolDate": "2017-05-15",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Ike.png",
@@ -13389,8 +13389,8 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Aug 31, 2017",
-      "poolDate": "Sep 15, 2017",
+      "releaseDate": "2017-08-31",
+      "poolDate": "2017-09-15",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Ike (Brave Heroes).png",
@@ -13512,7 +13512,7 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jan 31, 2018",
+      "releaseDate": "2018-01-31",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -13574,11 +13574,11 @@
           "rarity": "-"
         },
         {
-          "name": "Seal Atk Def 1",
+          "name": "Seal Atk/Def 1",
           "rarity": "-"
         },
         {
-          "name": "Seal Atk Def 2",
+          "name": "Seal Atk/Def 2",
           "rarity": 5
         },
         {
@@ -13643,7 +13643,7 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Sep 29, 2017",
+      "releaseDate": "2017-09-29",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -13752,8 +13752,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Aug 15, 2017",
-      "poolDate": "Aug 31, 2017",
+      "releaseDate": "2017-08-15",
+      "poolDate": "2017-08-31",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Innes.png",
@@ -13865,8 +13865,8 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Mar 14, 2017",
-      "poolDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-14",
+      "poolDate": "2017-03-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Jaffar.png",
@@ -13978,8 +13978,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Jagen.png",
@@ -14159,8 +14159,8 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Jakob.png",
@@ -14301,7 +14301,7 @@
       "weaponType": "Colorless Bow",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Oct 30, 2017",
+      "releaseDate": "2017-10-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -14415,8 +14415,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Jeorge.png",
@@ -14562,7 +14562,7 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Nov 21, 2017",
+      "releaseDate": "2017-11-21",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -14709,8 +14709,8 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 15, 2017",
-      "poolDate": "Feb 27, 2017",
+      "releaseDate": "2017-02-15",
+      "poolDate": "2017-02-27",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Julia.png",
@@ -14822,8 +14822,8 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Kagero.png",
@@ -14969,8 +14969,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Mar 14, 2017",
-      "poolDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-14",
+      "poolDate": "2017-03-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Karel.png",
@@ -15082,8 +15082,8 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jun 14, 2017",
-      "poolDate": "Jun 30, 2017",
+      "releaseDate": "2017-06-14",
+      "poolDate": "2017-06-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Katarina.png",
@@ -15195,8 +15195,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 27, 2017",
-      "poolDate": "Mar 14, 2017",
+      "releaseDate": "2017-02-27",
+      "poolDate": "2017-03-14",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Klein.png",
@@ -15342,8 +15342,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Jan 25, 2018",
-      "poolDate": "Feb 09, 2018",
+      "releaseDate": "2018-01-25",
+      "poolDate": "2018-02-09",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_L'Arachel.png",
@@ -15489,8 +15489,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 27, 2017",
-      "poolDate": "Mar 14, 2017",
+      "releaseDate": "2017-02-27",
+      "poolDate": "2017-03-14",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lachesis.png",
@@ -15720,8 +15720,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Laslow.png",
@@ -15901,7 +15901,7 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Jun 16, 2017",
+      "releaseDate": "2017-06-16",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -16082,8 +16082,8 @@
       "weaponType": "Red Tome",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Leo.png",
@@ -16195,7 +16195,7 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-28",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -16309,8 +16309,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Jul 13, 2017",
-      "poolDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-13",
+      "poolDate": "2017-07-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Leon.png",
@@ -16456,8 +16456,8 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lilina.png",
@@ -16603,7 +16603,7 @@
       "weaponType": "Green Tome",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Feb 09, 2018",
+      "releaseDate": "2018-02-09",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -16648,11 +16648,11 @@
           "rarity": "-"
         },
         {
-          "name": "HP Atk 1",
+          "name": "HP/Atk 1",
           "rarity": "-"
         },
         {
-          "name": "HP Atk 2",
+          "name": "HP/Atk 2",
           "rarity": 5
         },
         {
@@ -16717,8 +16717,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Linde.png",
@@ -16825,8 +16825,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lissa.png",
@@ -17072,7 +17072,7 @@
       "weaponType": "Green Axe",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Dec 18, 2017",
+      "releaseDate": "2017-12-18",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -17186,7 +17186,7 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "May 19, 2017",
+      "releaseDate": "2017-05-19",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -17405,8 +17405,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lon'qu.png",
@@ -17586,8 +17586,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lucina.png",
@@ -17704,8 +17704,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Aug 31, 2017",
-      "poolDate": "Sep 15, 2017",
+      "releaseDate": "2017-08-31",
+      "poolDate": "2017-09-15",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lucina (Brave Heroes).png",
@@ -17823,7 +17823,7 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -17932,8 +17932,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Mar 14, 2017",
-      "poolDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-14",
+      "poolDate": "2017-03-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lucius.png",
@@ -18077,8 +18077,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Apr 14, 2017",
-      "poolDate": "Apr 26, 2017",
+      "releaseDate": "2017-04-14",
+      "poolDate": "2017-04-26",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lukas.png",
@@ -18224,8 +18224,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Jun 14, 2017",
-      "poolDate": "Jun 30, 2017",
+      "releaseDate": "2017-06-14",
+      "poolDate": "2017-06-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Luke.png",
@@ -18337,8 +18337,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Nov 15, 2017",
-      "poolDate": "Nov 28, 2017",
+      "releaseDate": "2017-11-15",
+      "poolDate": "2017-11-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lute.png",
@@ -18382,11 +18382,11 @@
           "rarity": "-"
         },
         {
-          "name": "HP Res 1",
+          "name": "HP/Res 1",
           "rarity": "-"
         },
         {
-          "name": "HP Res 2",
+          "name": "HP/Res 2",
           "rarity": 5
         },
         {
@@ -18450,8 +18450,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lyn.png",
@@ -18568,8 +18568,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Aug 31, 2017",
-      "poolDate": "Sep 15, 2017",
+      "releaseDate": "2017-08-31",
+      "poolDate": "2017-09-15",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Lyn (Brave Heroes).png",
@@ -18686,7 +18686,7 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "May 30, 2017",
+      "releaseDate": "2017-05-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -18798,7 +18798,7 @@
       "weaponType": "Blue Tome",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Feb 09, 2018",
+      "releaseDate": "2018-02-09",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -18834,15 +18834,15 @@
           "rarity": "-"
         },
         {
-          "name": "Atk Spd Bond 1",
+          "name": "Atk/Spd Bond 1",
           "rarity": "-"
         },
         {
-          "name": "Atk Spd Bond 2",
+          "name": "Atk/Spd Bond 2",
           "rarity": "-"
         },
         {
-          "name": "Atk Spd Bond 3",
+          "name": "Atk/Spd Bond 3",
           "rarity": 5
         },
         {
@@ -18919,7 +18919,7 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Jan 26, 2018",
+      "releaseDate": "2018-01-26",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -18964,11 +18964,11 @@
           "rarity": 3
         },
         {
-          "name": "Attack Res 1",
+          "name": "Attack/Res 1",
           "rarity": 4
         },
         {
-          "name": "Attack Res 2",
+          "name": "Attack/Res 2",
           "rarity": 5
         },
         {
@@ -19100,8 +19100,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "May 15, 2017",
-      "poolDate": "May 30, 2017",
+      "releaseDate": "2017-05-15",
+      "poolDate": "2017-05-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Mae.png",
@@ -19242,8 +19242,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Maria.png",
@@ -19387,7 +19387,7 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Jan 31, 2018",
+      "releaseDate": "2018-01-31",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -19432,11 +19432,11 @@
           "rarity": "-"
         },
         {
-          "name": "HP Def 1",
+          "name": "HP/Def 1",
           "rarity": "-"
         },
         {
-          "name": "HP Def 2",
+          "name": "HP/Def 2",
           "rarity": 4
         },
         {
@@ -19534,8 +19534,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Marth.png",
@@ -19676,7 +19676,7 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Jun 08, 2017",
+      "releaseDate": "2017-06-08",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -19790,8 +19790,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Jul 13, 2017",
-      "poolDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-13",
+      "poolDate": "2017-07-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Mathilda.png",
@@ -19932,8 +19932,8 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "2-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Matthew.png",
@@ -20142,8 +20142,8 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Merric.png",
@@ -20289,8 +20289,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Nov 15, 2017",
-      "poolDate": "Nov 28, 2017",
+      "releaseDate": "2017-11-15",
+      "poolDate": "2017-11-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Mia.png",
@@ -20402,8 +20402,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jan 12, 2018",
-      "poolDate": "Jan 25, 2018",
+      "releaseDate": "2018-01-12",
+      "poolDate": "2018-01-25",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Micaiah.png",
@@ -20527,7 +20527,7 @@
       "weaponType": "Green Axe",
       "moveType": "Flying",
       "rarities": "3-4",
-      "releaseDate": "Mar 20, 2017",
+      "releaseDate": "2017-03-20",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -20700,8 +20700,8 @@
       "weaponType": "Green Axe",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Minerva.png",
@@ -20813,8 +20813,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Apr 26, 2017",
-      "poolDate": "May 15, 2017",
+      "releaseDate": "2017-04-26",
+      "poolDate": "2017-05-15",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Mist.png",
@@ -20868,11 +20868,11 @@
           "rarity": "-"
         },
         {
-          "name": "Spur Def Res 1",
+          "name": "Spur Def/Res 1",
           "rarity": "-"
         },
         {
-          "name": "Spur Def Res 2",
+          "name": "Spur Def/Res 2",
           "rarity": 5
         }
       ],
@@ -20924,7 +20924,7 @@
       "weaponType": "Blue Tome",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Mar 09, 2018",
+      "releaseDate": "2018-03-09",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -21050,7 +21050,7 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Mar 09, 2018",
+      "releaseDate": "2018-03-09",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -21107,11 +21107,11 @@
           "rarity": "-"
         },
         {
-          "name": "Spur Def Res 1",
+          "name": "Spur Def/Res 1",
           "rarity": "-"
         },
         {
-          "name": "Spur Def Res 2",
+          "name": "Spur Def/Res 2",
           "rarity": 5
         }
       ],
@@ -21164,8 +21164,8 @@
       "weaponType": "Green Breath",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Jan 25, 2018",
-      "poolDate": "Feb 09, 2018",
+      "releaseDate": "2018-01-25",
+      "poolDate": "2018-02-09",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Myrrh.png",
@@ -21277,7 +21277,7 @@
       "weaponType": "Green Axe",
       "moveType": "Flying",
       "rarities": "2-4",
-      "releaseDate": "Feb 10, 2017",
+      "releaseDate": "2017-02-10",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -21492,7 +21492,7 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Apr 04, 2017",
+      "releaseDate": "2017-04-04",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -21673,8 +21673,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Sep 15, 2017",
-      "poolDate": "Sep 29, 2017",
+      "releaseDate": "2017-09-15",
+      "poolDate": "2017-09-29",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Nephenee.png",
@@ -21718,11 +21718,11 @@
           "rarity": "-"
         },
         {
-          "name": "Atk Spd 1",
+          "name": "Atk/Spd 1",
           "rarity": "-"
         },
         {
-          "name": "Atk Spd 2",
+          "name": "Atk/Spd 2",
           "rarity": 5
         },
         {
@@ -21786,8 +21786,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Niles.png",
@@ -21967,8 +21967,8 @@
       "weaponType": "Blue Breath",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Mar 14, 2017",
-      "poolDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-14",
+      "poolDate": "2017-03-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Ninian.png",
@@ -22075,8 +22075,8 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Nino.png",
@@ -22251,8 +22251,8 @@
       "weaponType": "Blue Breath",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Nowi.png",
@@ -22393,7 +22393,7 @@
       "weaponType": "Red Tome",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Oct 30, 2017",
+      "releaseDate": "2017-10-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -22429,15 +22429,15 @@
           "rarity": "-"
         },
         {
-          "name": "Atk Res Bond 1",
+          "name": "Atk/Res Bond 1",
           "rarity": "-"
         },
         {
-          "name": "Atk Res Bond 2",
+          "name": "Atk/Res Bond 2",
           "rarity": "-"
         },
         {
-          "name": "Atk Res Bond 3",
+          "name": "Atk/Res Bond 3",
           "rarity": 5
         },
         {
@@ -22506,8 +22506,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Oboro.png",
@@ -22682,8 +22682,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Odin.png",
@@ -22863,8 +22863,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Ogma.png",
@@ -23010,7 +23010,7 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Jan 14, 2018",
+      "releaseDate": "2018-01-14",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -23191,8 +23191,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Olivia.png",
@@ -23218,7 +23218,7 @@
         },
         {
           "name": "Silver Sword+",
-          "default": "-",
+          "default": 5,
           "rarity": 5
         },
         {
@@ -23427,7 +23427,7 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Sep 29, 2017",
+      "releaseDate": "2017-09-29",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -23536,8 +23536,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Feb 27, 2017",
-      "poolDate": "Mar 14, 2017",
+      "releaseDate": "2017-02-27",
+      "poolDate": "2017-03-14",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Olwen.png",
@@ -23644,8 +23644,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Sep 15, 2017",
-      "poolDate": "Sep 29, 2017",
+      "releaseDate": "2017-09-15",
+      "poolDate": "2017-09-29",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Oscar.png",
@@ -23701,11 +23701,11 @@
           "rarity": "-"
         },
         {
-          "name": "Spur Spd Def 1",
+          "name": "Spur Spd/Def 1",
           "rarity": 4
         },
         {
-          "name": "Spur Spd Def 2",
+          "name": "Spur Spd/Def 2",
           "rarity": 5
         }
       ],
@@ -23791,8 +23791,8 @@
       "weaponType": "Red Sword",
       "moveType": "Flying",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Palla.png",
@@ -23972,8 +23972,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Peri.png",
@@ -24119,8 +24119,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Mar 14, 2017",
-      "poolDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-14",
+      "poolDate": "2017-03-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Priscilla.png",
@@ -24264,8 +24264,8 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "2-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Raigh.png",
@@ -24474,8 +24474,8 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Raven.png",
@@ -24621,8 +24621,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Mar 14, 2017",
-      "poolDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-14",
+      "poolDate": "2017-03-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Rebecca.png",
@@ -24763,8 +24763,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Feb 27, 2017",
-      "poolDate": "Mar 14, 2017",
+      "releaseDate": "2017-02-27",
+      "poolDate": "2017-03-14",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Reinhardt.png",
@@ -24910,8 +24910,8 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Dec 02, 2017",
-      "poolDate": "Dec 14, 2017",
+      "releaseDate": "2017-12-02",
+      "poolDate": "2017-12-14",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Rhajat.png",
@@ -25023,7 +25023,7 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "2-4",
-      "releaseDate": "Feb 23, 2017",
+      "releaseDate": "2017-02-23",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -25239,7 +25239,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jun 30, 2017",
+      "releaseDate": "2017-06-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -25279,11 +25279,11 @@
           "rarity": "-"
         },
         {
-          "name": "HP Def 1",
+          "name": "HP/Def 1",
           "rarity": "-"
         },
         {
-          "name": "HP Def 2",
+          "name": "HP/Def 2",
           "rarity": 5
         },
         {
@@ -25348,8 +25348,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Robin (M).png",
@@ -25530,8 +25530,8 @@
       "weaponType": "Green Breath",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Feb 22, 2018",
-      "poolDate": "Mar 09, 2018",
+      "releaseDate": "2018-02-22",
+      "poolDate": "2018-03-09",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Robin (M) (Fallen Heroes).png",
@@ -25644,7 +25644,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Dec 18, 2017",
+      "releaseDate": "2017-12-18",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -25680,15 +25680,15 @@
           "rarity": "-"
         },
         {
-          "name": "Brazen Atk Spd 1",
+          "name": "Brazen Atk/Spd 1",
           "rarity": "-"
         },
         {
-          "name": "Brazen Atk Spd 2",
+          "name": "Brazen Atk/Spd 2",
           "rarity": "-"
         },
         {
-          "name": "Brazen Atk Spd 3",
+          "name": "Brazen Atk/Spd 3",
           "rarity": 5
         },
         {
@@ -25753,8 +25753,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Jun 14, 2017",
-      "poolDate": "Jun 30, 2017",
+      "releaseDate": "2017-06-14",
+      "poolDate": "2017-06-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Roderick.png",
@@ -25892,8 +25892,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Roy.png",
@@ -26034,8 +26034,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Aug 31, 2017",
-      "poolDate": "Sep 15, 2017",
+      "releaseDate": "2017-08-31",
+      "poolDate": "2017-09-15",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Roy (Brave Heroes).png",
@@ -26153,7 +26153,7 @@
       "weaponType": "Colorless Bow",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Feb 09, 2018",
+      "releaseDate": "2018-02-09",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -26262,8 +26262,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Ryoma.png",
@@ -26375,8 +26375,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jul 13, 2017",
-      "poolDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-13",
+      "poolDate": "2017-07-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Saber.png",
@@ -26420,11 +26420,11 @@
           "rarity": "-"
         },
         {
-          "name": "HP Spd 1",
+          "name": "HP/Spd 1",
           "rarity": "-"
         },
         {
-          "name": "HP Spd 2",
+          "name": "HP/Spd 2",
           "rarity": 5
         },
         {
@@ -26488,8 +26488,8 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Saizo.png",
@@ -26664,8 +26664,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Sakura.png",
@@ -26809,7 +26809,7 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Oct 30, 2017",
+      "releaseDate": "2017-10-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -26935,8 +26935,8 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 27, 2017",
-      "poolDate": "Mar 14, 2017",
+      "releaseDate": "2017-02-27",
+      "poolDate": "2017-03-14",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Sanaki.png",
@@ -27043,8 +27043,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Selena.png",
@@ -27219,8 +27219,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 15, 2017",
-      "poolDate": "Feb 27, 2017",
+      "releaseDate": "2017-02-15",
+      "poolDate": "2017-02-27",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Seliph.png",
@@ -27361,8 +27361,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Serra.png",
@@ -27540,8 +27540,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Aug 15, 2017",
-      "poolDate": "Aug 31, 2017",
+      "releaseDate": "2017-08-15",
+      "poolDate": "2017-08-31",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Seth.png",
@@ -27592,11 +27592,11 @@
           "rarity": "-"
         },
         {
-          "name": "Seal Atk Def 1",
+          "name": "Seal Atk/Def 1",
           "rarity": 4
         },
         {
-          "name": "Seal Atk Def 2",
+          "name": "Seal Atk/Def 2",
           "rarity": 5
         }
       ],
@@ -27682,8 +27682,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Setsuna.png",
@@ -27858,8 +27858,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Shanna.png",
@@ -28039,7 +28039,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "2",
-      "releaseDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -28249,8 +28249,8 @@
       "weaponType": "Green Axe",
       "moveType": "Armored",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Sheena.png",
@@ -28388,7 +28388,7 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Sep 29, 2017",
+      "releaseDate": "2017-09-29",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -28497,8 +28497,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Dec 04, 2017",
-      "poolDate": "Dec 18, 2017",
+      "releaseDate": "2017-12-04",
+      "poolDate": "2017-12-18",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Shiro.png",
@@ -28605,8 +28605,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Dec 04, 2017",
-      "poolDate": "Dec 18, 2017",
+      "releaseDate": "2017-12-04",
+      "poolDate": "2017-12-18",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Siegbert.png",
@@ -28718,8 +28718,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Oct 16, 2017",
-      "poolDate": "Oct 30, 2017",
+      "releaseDate": "2017-10-16",
+      "poolDate": "2017-10-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Sigurd.png",
@@ -28830,8 +28830,8 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Dec 04, 2017",
-      "poolDate": "Dec 18, 2017",
+      "releaseDate": "2017-12-04",
+      "poolDate": "2017-12-18",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Soleil.png",
@@ -28977,8 +28977,8 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jul 13, 2017",
-      "poolDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-13",
+      "poolDate": "2017-07-28",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Sonya.png",
@@ -29090,8 +29090,8 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Sophia.png",
@@ -29339,8 +29339,8 @@
       "weaponType": "Green Tome",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Apr 26, 2017",
-      "poolDate": "May 15, 2017",
+      "releaseDate": "2017-04-26",
+      "poolDate": "2017-05-15",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Soren.png",
@@ -29486,8 +29486,8 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Jan 12, 2018",
-      "poolDate": "Jan 25, 2018",
+      "releaseDate": "2018-01-12",
+      "poolDate": "2018-01-25",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Sothe.png",
@@ -29543,11 +29543,11 @@
           "rarity": "-"
         },
         {
-          "name": "Spur Atk Spd 1",
+          "name": "Spur Atk/Spd 1",
           "rarity": 4
         },
         {
-          "name": "Spur Atk Spd 2",
+          "name": "Spur Atk/Spd 2",
           "rarity": 5
         }
       ],
@@ -29633,8 +29633,8 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Stahl.png",
@@ -29877,8 +29877,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Subaki.png",
@@ -30121,8 +30121,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Sully.png",
@@ -30340,8 +30340,8 @@
       "weaponType": "Blue Tome",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Oct 16, 2017",
-      "poolDate": "Oct 30, 2017",
+      "releaseDate": "2017-10-16",
+      "poolDate": "2017-10-30",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Tailtiu.png",
@@ -30385,11 +30385,11 @@
           "rarity": "-"
         },
         {
-          "name": "Attack Res 1",
+          "name": "Attack/Res 1",
           "rarity": 4
         },
         {
-          "name": "Attack Res 2",
+          "name": "Attack/Res 2",
           "rarity": 5
         },
         {
@@ -30487,8 +30487,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Takumi.png",
@@ -30592,7 +30592,7 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 24, 2018",
+      "releaseDate": "2018-02-24",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -30774,7 +30774,7 @@
       "weaponType": "Colorless Dagger",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Dec 31, 2017",
+      "releaseDate": "2017-12-31",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -30815,15 +30815,15 @@
           "rarity": 5
         },
         {
-          "name": "Atk Res Bond 1",
+          "name": "Atk/Res Bond 1",
           "rarity": "-"
         },
         {
-          "name": "Atk Res Bond 2",
+          "name": "Atk/Res Bond 2",
           "rarity": "-"
         },
         {
-          "name": "Atk Res Bond 3",
+          "name": "Atk/Res Bond 3",
           "rarity": 5
         },
         {
@@ -30888,8 +30888,8 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "5",
-      "releaseDate": "Aug 15, 2017",
-      "poolDate": "Aug 31, 2017",
+      "releaseDate": "2017-08-15",
+      "poolDate": "2017-08-31",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Tana.png",
@@ -30933,11 +30933,11 @@
           "rarity": "-"
         },
         {
-          "name": "Spd Def 1",
+          "name": "Spd/Def 1",
           "rarity": "-"
         },
         {
-          "name": "Spd Def 2",
+          "name": "Spd/Def 2",
           "rarity": 5
         },
         {
@@ -31001,8 +31001,8 @@
       "weaponType": "Red Tome",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Tharja.png",
@@ -31148,7 +31148,7 @@
       "weaponType": "Red Tome",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Dec 18, 2017",
+      "releaseDate": "2017-12-18",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -31266,8 +31266,8 @@
       "weaponType": "Red Breath",
       "moveType": "Infantry",
       "rarities": "3-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Tiki (Adult).png",
@@ -31448,7 +31448,7 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jun 30, 2017",
+      "releaseDate": "2017-06-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -31562,8 +31562,8 @@
       "weaponType": "Red Breath",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Tiki (Young).png",
@@ -31676,8 +31676,8 @@
       "weaponType": "Green Axe",
       "moveType": "Cavalry",
       "rarities": "4-5",
-      "releaseDate": "Apr 26, 2017",
-      "poolDate": "May 15, 2017",
+      "releaseDate": "2017-04-26",
+      "poolDate": "2017-05-15",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Titania.png",
@@ -31818,7 +31818,7 @@
       "weaponType": "Red Sword",
       "moveType": "Infantry",
       "rarities": "4-5",
-      "releaseDate": "Jul 07, 2017",
+      "releaseDate": "2017-07-07",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -31960,7 +31960,7 @@
       "weaponType": "Blue Tome",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "Mar 10, 2017",
+      "releaseDate": "2017-03-10",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -32141,7 +32141,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Flying",
       "rarities": "3-4",
-      "releaseDate": "Aug 21, 2017",
+      "releaseDate": "2017-08-21",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -32365,8 +32365,8 @@
       "weaponType": "Colorless Bow",
       "moveType": "Infantry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Virion.png",
@@ -32614,8 +32614,8 @@
       "weaponType": "Colorless Staff",
       "moveType": "Infantry",
       "rarities": "1-4",
-      "releaseDate": "Feb 02, 2017",
-      "poolDate": "Feb 02, 2017",
+      "releaseDate": "2017-02-02",
+      "poolDate": "2017-02-02",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Wrys.png",
@@ -32861,7 +32861,7 @@
       "weaponType": "Red Sword",
       "moveType": "Cavalry",
       "rarities": "3-4",
-      "releaseDate": "May 02, 2017",
+      "releaseDate": "2017-05-02",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -33042,7 +33042,7 @@
       "weaponType": "Green Axe",
       "moveType": "Infantry",
       "rarities": "5",
-      "releaseDate": "Jul 28, 2017",
+      "releaseDate": "2017-07-28",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -33156,7 +33156,7 @@
       "weaponType": "Blue Lance",
       "moveType": "Cavalry",
       "rarities": "5",
-      "releaseDate": "Mar 30, 2017",
+      "releaseDate": "2017-03-30",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -33257,8 +33257,8 @@
       "weaponType": "Red Sword",
       "moveType": "Armored",
       "rarities": "5",
-      "releaseDate": "Jan 12, 2018",
-      "poolDate": "Jan 25, 2018",
+      "releaseDate": "2018-01-12",
+      "poolDate": "2018-01-25",
       "assets": {
         "portrait": {
           "75px": "https://proving-grounds-static.ajhyndman.com/75px-Icon_Portrait_Zelgius.png",
@@ -33379,7 +33379,7 @@
       "weaponType": "Red Sword",
       "moveType": "Armored",
       "rarities": "3-4",
-      "releaseDate": "Apr 20, 2017",
+      "releaseDate": "2017-04-20",
       "poolDate": "N/A",
       "assets": {
         "portrait": {
@@ -33613,7 +33613,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Sword"
     },
     {
       "name": "Armorslayer+",
@@ -33623,7 +33623,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Sword"
     },
     {
       "name": "Armorsmasher",
@@ -33633,7 +33633,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Sword"
     },
     {
       "name": "Armorsmasher+",
@@ -33643,7 +33643,7 @@
       "effect": "Effective against armored foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Sword"
     },
     {
       "name": "Assassin's Bow",
@@ -33913,7 +33913,7 @@
       "effect": "Grants Def/Res+6 during combat if foe initiates combat and uses bow, dagger, magic, or staff.",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Tome"
     },
     {
       "name": "Blárserpent+",
@@ -33923,7 +33923,7 @@
       "effect": "Grants Def/Res+6 during combat if foe initiates combat and uses bow, dagger, magic, or staff.",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Tome"
     },
     {
       "name": "Blárwolf",
@@ -33933,7 +33933,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Tome"
     },
     {
       "name": "Blárwolf+",
@@ -33943,7 +33943,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Tome"
     },
     {
       "name": "Bolganone",
@@ -34380,7 +34380,7 @@
       "spCost": 400,
       "damage(mt)": 14,
       "range(rng)": 2,
-      "effect": "Effective against dragons. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> Foe",
+      "effect": "Effective against dragons. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> Foe's bonuses (from skills like Fortify, Rally, etc.) are nullified during combat.",
       "exclusive?": "Yes",
       "type": "WEAPON",
       "weaponType": "Green Tome"
@@ -34483,7 +34483,7 @@
       "effect": "Effective against flying units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "Yes",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Tome"
     },
     {
       "name": "Expiration",
@@ -34500,7 +34500,7 @@
       "spCost": 400,
       "damage(mt)": 16,
       "range(rng)": 1,
-      "effect": "Effective against dragons. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> At",
+      "effect": "Effective against dragons. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> At the start of every third turn, unit recovers 10 HP.",
       "exclusive?": "Yes",
       "type": "WEAPON",
       "weaponType": "Red Sword"
@@ -34863,7 +34863,7 @@
       "effect": "Grants Def+3. After combat, if unit attacked, inflicts Atk/Spd-5 on target and foes within 2 spaces of target through their next actions, and grants Atk/Spd+5 to unit and allies within 2 spaces for 1 turn.",
       "exclusive?": "Yes",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Tome"
     },
     {
       "name": "Grimoire",
@@ -34943,7 +34943,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Tome"
     },
     {
       "name": "Gronnwolf+",
@@ -34953,7 +34953,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Tome"
     },
     {
       "name": "Guard Bow",
@@ -35023,7 +35023,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Axe"
     },
     {
       "name": "Hammer+",
@@ -35033,7 +35033,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Axe"
     },
     {
       "name": "Handbell",
@@ -35073,7 +35073,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Lance"
     },
     {
       "name": "Heavy Spear+",
@@ -35083,7 +35083,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Lance"
     },
     {
       "name": "Hibiscus Tome",
@@ -35223,7 +35223,7 @@
       "effect": "Effective against cavalry foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Tome"
     },
     {
       "name": "Keen Blárwolf+",
@@ -35233,7 +35233,7 @@
       "effect": "Effective against cavalry foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Tome"
     },
     {
       "name": "Keen Gronnwolf",
@@ -35243,7 +35243,7 @@
       "effect": "Effective against cavalry foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Tome"
     },
     {
       "name": "Keen Gronnwolf+",
@@ -35253,7 +35253,7 @@
       "effect": "Effective against cavalry foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Tome"
     },
     {
       "name": "Keen Rauðrwolf",
@@ -35263,7 +35263,7 @@
       "effect": "Effective against cavalry foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Tome"
     },
     {
       "name": "Keen Rauðrwolf+",
@@ -35273,7 +35273,7 @@
       "effect": "Effective against cavalry foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Tome"
     },
     {
       "name": "Killer Axe",
@@ -35360,23 +35360,23 @@
       "spCost": 200,
       "damage(mt)": 5,
       "range(rng)": 2,
-      "effect": "Effective against magic foes. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span><span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span><span style=\"position:relative;to",
+      "effect": "Effective against magic foes. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span><span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span><span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> After combat, if unit attacked and if foe uses magic, inflicts Def/Res-5 on foe through its next action.",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Colorless Dagger"
     },
     {
       "name": "Kitty Paddle+",
       "spCost": 300,
       "damage(mt)": 8,
       "range(rng)": 2,
-      "effect": "Effective against magic foes. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span><span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span><span style=\"position:relative;to",
+      "effect": "Effective against magic foes. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span><span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span><span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> After combat, if unit attacked and if foe uses magic, inflicts Def/Res-7 on foe through its next action.",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Colorless Dagger"
     },
     {
-      "name": "Laevatein (Weapon)",
+      "name": "Laevatein",
       "spCost": 400,
       "damage(mt)": 16,
       "range(rng)": 1,
@@ -35550,7 +35550,7 @@
       "spCost": 400,
       "damage(mt)": 14,
       "range(rng)": 2,
-      "effect": "Effective against dragons. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> Gra",
+      "effect": "Effective against dragons. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> Grants Def/Res+2 when this unit is attacked.",
       "exclusive?": "Yes",
       "type": "WEAPON",
       "weaponType": "Green Tome"
@@ -35663,7 +35663,7 @@
       "effect": "Effective against infantry foes. <span style=\"position: relative; top: -1px\"></span>  After combat, if unit attacked, inflicts Def/Res-4 on infantry foe through its next action.",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Colorless Dagger"
     },
     {
       "name": "Poison Dagger+",
@@ -35673,7 +35673,7 @@
       "effect": "Effective against infantry foes. <span style=\"position: relative; top: -1px\"></span>  After combat, if unit attacked, inflicts Def/Res-6 on infantry foe through its next action.",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Colorless Dagger"
     },
     {
       "name": "Poleaxe",
@@ -35683,7 +35683,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Axe"
     },
     {
       "name": "Poleaxe+",
@@ -35693,7 +35693,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Axe"
     },
     {
       "name": "Ragnarok",
@@ -35793,7 +35793,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Tome"
     },
     {
       "name": "Rauðrwolf+",
@@ -35803,7 +35803,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Tome"
     },
     {
       "name": "Refreshing Bolt",
@@ -35873,7 +35873,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Lance"
     },
     {
       "name": "Ridersbane+",
@@ -35883,7 +35883,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Lance"
     },
     {
       "name": "Rogue Dagger",
@@ -35980,7 +35980,7 @@
       "spCost": 400,
       "damage(mt)": 16,
       "range(rng)": 1,
-      "effect": "Effective against dragon foes. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> I",
+      "effect": "Effective against dragon foes. <span style=\"position:relative;top:-1px;left:-1px;margin-right:2px\"></span> If unit's HP < 100% at start of combat, grants Atk/Spd/Def/Res+5 during combat.",
       "exclusive?": "Yes",
       "type": "WEAPON",
       "weaponType": "Red Sword"
@@ -36263,7 +36263,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Axe"
     },
     {
       "name": "Slaying Hammer+",
@@ -36273,7 +36273,7 @@
       "effect": "Effective against armored foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Green Axe"
     },
     {
       "name": "Slaying Lance",
@@ -36303,7 +36303,7 @@
       "effect": "Effective against armored units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Lance"
     },
     {
       "name": "Slaying Spear+",
@@ -36313,7 +36313,7 @@
       "effect": "Effective against armored foes. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Lance"
     },
     {
       "name": "Slow",
@@ -36470,10 +36470,10 @@
       "spCost": 400,
       "damage(mt)": 14,
       "range(rng)": 2,
-      "effect": "Grants Res+3. Effective against armored and cavalry foes. <span style=\"position: relative; top: -1px\"></span> <span style=\"position: relative; top: -1px\"></span>  Against armored and cavalry foes using bow, dagger,",
+      "effect": "Grants Res+3. Effective against armored and cavalry foes. <span style=\"position: relative; top: -1px\"></span> <span style=\"position: relative; top: -1px\"></span>  Against armored and cavalry foes using bow, dagger, magic, or staff, damage from first attack received by unit during combat reduced by 30%.",
       "exclusive?": "Yes",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Blue Tome"
     },
     {
       "name": "Thoron",
@@ -36633,7 +36633,7 @@
       "effect": "Effective against armored and cavalry foes. <span style=\"position: relative; top: -1px\"></span> <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "Yes",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Sword"
     },
     {
       "name": "Wo Dao",
@@ -36673,7 +36673,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Sword"
     },
     {
       "name": "Zanbato+",
@@ -36683,7 +36683,7 @@
       "effect": "Effective against cavalry units. <span style=\"position: relative; top: -1px\"></span>",
       "exclusive?": "No",
       "type": "WEAPON",
-      "weaponType": ""
+      "weaponType": "Red Sword"
     },
     {
       "name": "Élivágar",
@@ -38094,58 +38094,33 @@
       "type": "SPECIAL"
     },
     {
-      "name": "HP Def 1",
-      "effect": "Grants HP+3, Def+1.",
+      "name": "Distant Counter",
+      "effect": "Enables unit to counterattack regardless of distance to attacker.",
       "exclusive": false,
-      "spCost": 100,
+      "spCost": 300,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
       "type": "PASSIVE_A"
     },
     {
-      "name": "Armor March 2",
-      "effect": "If unit has ≥ 50% HP and an adjacent armored ally at start of turn, unit and any such allies can move 1 extra space. (That turn only; does not stack.)",
+      "name": "HP/Def 2",
+      "effect": "Grants HP+4, Def+2.",
       "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Armor March 3",
-      "effect": "If unit has an adjacent armored ally at the start of turn, unit and any such allies can move 1 extra space. (That turn only; does not stack.)",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Armored Blow 1",
-      "effect": "Grants Def+2 during combat if unit initiates the attack.",
-      "exclusive": false,
-      "spCost": 50,
+      "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
       "type": "PASSIVE_A"
     },
@@ -38176,7 +38151,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Def Bond 1",
+      "name": "Atk/Def Bond 1",
       "effect": "Grants Atk/Def+3 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 60,
@@ -38189,7 +38164,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Def Bond 2",
+      "name": "Atk/Def Bond 2",
       "effect": "Grants Atk/Def+4 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 120,
@@ -38202,7 +38177,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Def Bond 3",
+      "name": "Atk/Def Bond 3",
       "effect": "Grants Atk/Def+5 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 240,
@@ -38215,46 +38190,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Ploy 1",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Atk-3 until the end of foe's next action.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Atk Ploy 2",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Atk-4 until the end of foe's next action.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Atk Ploy 3",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Atk-5 until the end of foe's next action.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Atk Res Bond 1",
+      "name": "Atk/Res Bond 1",
       "effect": "Grants Atk/Res+3 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 60,
@@ -38267,7 +38203,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Res Bond 2",
+      "name": "Atk/Res Bond 2",
       "effect": "Grants Atk/Res+4 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 120,
@@ -38280,7 +38216,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Res Bond 3",
+      "name": "Atk/Res Bond 3",
       "effect": "Grants Atk/Res+5 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 240,
@@ -38293,46 +38229,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Smoke 1",
-      "effect": "After combat, inflicts Atk-3 on foes within 2 spaces of target through their next actions.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Atk Smoke 2",
-      "effect": "After combat, inflicts Atk-5 on foes within 2 spaces of target through their next actions.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Atk Smoke 3",
-      "effect": "After combat, inflicts Atk-7 on foes within 2 spaces of target through their next actions.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Atk Spd 1",
+      "name": "Atk/Spd 1",
       "effect": "Grants Atk/Spd+1.",
       "exclusive": false,
       "spCost": 80,
@@ -38345,7 +38242,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Spd 2",
+      "name": "Atk/Spd 2",
       "effect": "Grants Atk/Spd+2.",
       "exclusive": false,
       "spCost": 160,
@@ -38358,7 +38255,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Spd Bond 1",
+      "name": "Atk/Spd Bond 1",
       "effect": "Grants Atk/Spd+3 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 60,
@@ -38371,7 +38268,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Spd Bond 2",
+      "name": "Atk/Spd Bond 2",
       "effect": "Grants Atk/Spd+4 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 120,
@@ -38384,7 +38281,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Atk Spd Bond 3",
+      "name": "Atk/Spd Bond 3",
       "effect": "Grants Atk/Spd+5 to this unit during combat if unit is adjacent to an ally.",
       "exclusive": false,
       "spCost": 240,
@@ -38395,45 +38292,6 @@
         ""
       ],
       "type": "PASSIVE_A"
-    },
-    {
-      "name": "Atk Tactic 1",
-      "effect": "At start of turn, grants Atk+2 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Atk Tactic 2",
-      "effect": "At start of turn, grants Atk+4 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Atk Tactic 3",
-      "effect": "At start of turn, grants Atk+6 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
     },
     {
       "name": "Attack +1",
@@ -38475,7 +38333,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Attack Def +1",
+      "name": "Attack/Def +1",
       "effect": "Grants Atk/Def+1.",
       "exclusive": false,
       "spCost": 80,
@@ -38488,7 +38346,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Attack Def +2",
+      "name": "Attack/Def +2",
       "effect": "Grants Atk/Def+2.",
       "exclusive": false,
       "spCost": 160,
@@ -38501,7 +38359,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Attack Res 1",
+      "name": "Attack/Res 1",
       "effect": "Grants Atk/Res+1.",
       "exclusive": false,
       "spCost": 80,
@@ -38514,7 +38372,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Attack Res 2",
+      "name": "Attack/Res 2",
       "effect": "Grants Atk/Res+2.",
       "exclusive": false,
       "spCost": 160,
@@ -38527,644 +38385,140 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Axe Experience 1",
-      "effect": "If unit survives, unit gets 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Axe Experience 2",
-      "effect": "If unit survives, all axe users on team get 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Axe Experience 3",
-      "effect": "If unit survives, all axe users on team get 2x EXP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Axe Valor 1",
-      "effect": "If unit survives and uses an axe, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Axe Valor 2",
-      "effect": "If unit survives, all axe users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Axe Valor 3",
-      "effect": "If unit survives, all axe users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Axebreaker 1",
-      "effect": "If unit's HP ≥ 90% in combat against an axe user, unit makes a follow-up attack and foe cannot.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Blue Lance",
-        "Blue Tome",
-        "Blue Breath"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Axebreaker 2",
-      "effect": "If unit's HP ≥ 70% in combat against an axe user, unit makes a follow-up attack and foe cannot.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Blue Lance",
-        "Blue Tome",
-        "Blue Breath"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Axebreaker 3",
-      "effect": "If unit's HP ≥ 50% in combat against an axe user, unit makes a follow-up attack and foe cannot.",
+      "name": "Wind Boost 3",
+      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Spd+6 during combat.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Blue Lance",
-        "Blue Tome",
-        "Blue Breath"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "B Tome Exp. 1",
-      "effect": "If using blue magic and unit survives combat, unit gets 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
         ""
       ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "B Tome Exp. 2",
-      "effect": "If unit survives combat, all blue magic users on team get 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "B Tome Exp. 3",
-      "effect": "If unit survives combat, all blue magic users on team get 2x EXP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "B Tome Valor 1",
-      "effect": "If unit survives and uses a blue tome, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "B Tome Valor 2",
-      "effect": "If unit survives, all blue tome users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "B Tome Valor 3",
-      "effect": "If unit survives, all blue tome users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "B Tomebreaker 1",
-      "effect": "If unit's HP ≥ 90% in combat against a blue tome user, unit makes a follow-up attack and foe cannot.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Red Tome",
-        "Red Breath"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "B Tomebreaker 2",
-      "effect": "If unit's HP ≥ 70% in combat against a blue tome user, unit makes a follow-up attack and foe cannot.",
+      "name": "Wind Boost 2",
+      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Spd+4 during combat.",
       "exclusive": false,
       "spCost": 100,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Red Sword",
-        "Red Tome",
-        "Red Breath"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "B Tomebreaker 3",
-      "effect": "If unit's HP ≥ 50% in combat against a blue tome user, unit makes a follow-up attack and foe cannot.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
         ""
       ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Red Tome",
-        "Red Breath"
-      ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Beorc's Blessing",
-      "effect": "If foe is cavalry or flier type, foe's bonuses (from skills like Fortify, Rally, etc.) are nullified during combat. (Skill cannot be inherited.)",
-      "exclusive": true,
-      "spCost": 300,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Blaze Dance 1",
-      "effect": "If Sing or Dance is used, target also granted Atk+2.",
+      "name": "Wind Boost 1",
+      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Spd+2 during combat.",
       "exclusive": false,
       "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Blaze Dance 2",
-      "effect": "If Sing or Dance is used, target also granted Atk+3.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
         ""
       ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Blaze Dance 3",
-      "effect": "If Sing or Dance is used, target also granted Atk+4.",
+      "name": "Water Boost 3",
+      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Res+6 during combat.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Bold Fighter 1",
-      "effect": "If unit's HP = 100% and unit initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
+      "name": "Water Boost 2",
+      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Res+4 during combat.",
       "exclusive": false,
-      "spCost": 60,
+      "spCost": 100,
       "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
+        ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Bold Fighter 2",
-      "effect": "If unit's HP ≥ 50% and unit initiates combat, unit makes a guaranteed follow-up attack.<Br>Grants Special cooldown charge +1 per attack. (Does not stack.)",
+      "name": "Water Boost 1",
+      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Res+2 during combat.",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 50,
       "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
+        ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Bold Fighter 3",
-      "effect": "If unit initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
+      "name": "Warding Stance 3",
+      "effect": "Grants Res+6 during combat when this unit is attacked.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Warding Stance 2",
+      "effect": "Grants Res+4 during combat when this unit is attacked.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Warding Stance 1",
+      "effect": "Grants Res+2 during combat when this unit is attacked.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Warding Breath",
+      "effect": "Grants Res+4 during combat if unit is attacked. Also grants Special cooldown charge +1 per attack. (Does not stack. Only highest value applied.)",
       "exclusive": false,
       "spCost": 240,
       "movementRestriction": [
-        "Infantry",
         "Cavalry",
         "Flying"
       ],
       "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Bow Exp. 1",
-      "effect": "If unit survives and uses a bow, unit gets 1.5x EXP. (If similar skill effects also used, only highest multiplier applies.)",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
         "Red Tome",
         "Blue Tome",
         "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
+        "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Bow Exp. 2",
-      "effect": "If unit survives, all bow users on team get 1.5x EXP. (If similar skill effects also used, only highest multiplier applies.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Bow Exp. 3",
-      "effect": "If unit survives, all bow users on team get 2x EXP. (If similar skill effects also used, only highest multiplier applies.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Bow Valor 1",
-      "effect": "If unit survives and uses a bow, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Bow Valor 2",
-      "effect": "If unit survives, all bow users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Bow Valor 3",
-      "effect": "If unit survives, all bow users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Bowbreaker 1",
-      "effect": "If unit's HP ≥ 90% in combat against a colorless bow foe, unit makes a guaranteed follow-up attack and foe cannot make a follow-up attack.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Bowbreaker 2",
-      "effect": "If unit's HP ≥ 70% in combat against a colorless bow foe, unit makes a guaranteed follow-up attack and foe cannot make a follow-up attack.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Bowbreaker 3",
-      "effect": "If unit's HP ≥ 50% in combat against a colorless bow foe, unit makes a guaranteed follow-up attack and foe cannot make a follow-up attack.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
       "name": "Bracing Blow 1",
@@ -39193,46 +38547,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brash Assault 1",
-      "effect": "If unit initiates combat against a foe that can counter and unit's HP ≤ 30%, unit makes a guaranteed follow-up attack.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Brash Assault 2",
-      "effect": "If unit initiates combat against a foe that can counter and unit's HP ≤ 40%, unit makes a guaranteed follow-up attack.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Brash Assault 3",
-      "effect": "If unit initiates combat against a foe that can counter and unit's HP ≤ 50%, unit makes a guaranteed follow-up attack.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Brazen Atk Def 1",
+      "name": "Brazen Atk/Def 1",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Atk/Def+3 during combat.",
       "exclusive": false,
       "spCost": 60,
@@ -39245,7 +38560,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brazen Atk Def 2",
+      "name": "Brazen Atk/Def 2",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Atk/Def+5 during combat.",
       "exclusive": false,
       "spCost": 120,
@@ -39258,7 +38573,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brazen Atk Def 3",
+      "name": "Brazen Atk/Def 3",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Atk/Def+7 during combat.",
       "exclusive": false,
       "spCost": 240,
@@ -39271,7 +38586,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brazen Atk Spd 1",
+      "name": "Brazen Atk/Spd 1",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Atk/Spd+3 during combat.",
       "exclusive": false,
       "spCost": 60,
@@ -39284,7 +38599,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brazen Atk Spd 2",
+      "name": "Brazen Atk/Spd 2",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Atk/Spd+5 during combat.",
       "exclusive": false,
       "spCost": 120,
@@ -39297,7 +38612,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brazen Atk Spd 3",
+      "name": "Brazen Atk/Spd 3",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Atk/Spd+7 during combat.",
       "exclusive": false,
       "spCost": 240,
@@ -39310,7 +38625,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brazen Def Res 1",
+      "name": "Brazen Def/Res 1",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Def/Res+3 during combat.",
       "exclusive": false,
       "spCost": 60,
@@ -39323,7 +38638,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brazen Def Res 2",
+      "name": "Brazen Def/Res 2",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Def/Res+5 during combat.",
       "exclusive": false,
       "spCost": 120,
@@ -39336,7 +38651,7 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Brazen Def Res 3",
+      "name": "Brazen Def/Res 3",
       "effect": "If unit's HP ≤ 80% at the start of combat, grants Def/Res+7 during combat.",
       "exclusive": false,
       "spCost": 240,
@@ -39349,182 +38664,43 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Breath of Life 1",
-      "effect": "If unit initiates attack, adjacent allies recover 3 HP after combat.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Breath of Life 2",
-      "effect": "If unit initiates attack, adjacent allies recover 5 HP after combat.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Breath of Life 3",
-      "effect": "If unit initiates attack, adjacent allies recover 7 HP after combat.",
+      "name": "Warding Blow 3",
+      "effect": "Grants Res+6 during combat if unit initiates attack.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Cancel Affinity 1",
-      "effect": "Any weapon triangle affinity granted by unit's skills is negated. Also negates any weapon triangle affinity granted by foe's skills.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Cancel Affinity 2",
-      "effect": "Any weapon triangle affinity granted by unit's skills is negated. If affinity disadvantage exists, weapon triangle affinity granted by foe's skills is negated.",
+      "name": "Warding Blow 2",
+      "effect": "Grants Res+4 during combat if unit initiates attack.",
       "exclusive": false,
       "spCost": 100,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Cancel Affinity 3",
-      "effect": "Any weapon triangle affinity granted by unit's skills is negated. If affinity disadvantage exists, weapon triangle affinity granted by foe's skills is reversed.",
+      "name": "Warding Blow 1",
+      "effect": "Grants Res+2 during combat if unit initiates attack.",
       "exclusive": false,
-      "spCost": 200,
+      "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Chill Def 1",
-      "effect": "At the start of each turn, inflicts Def-3 on foe on the enemy team with the highest Def through its next action.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Chill Def 2",
-      "effect": "At the start of each turn, inflicts Def-5 on foe on the enemy team with the highest Def through its next action.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Chill Def 3",
-      "effect": "At the start of each turn, inflicts Def-7 on foe on the enemy team with the highest Def through its next action.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Chill Spd 1",
-      "effect": "At the start of each turn, inflicts Spd-3 on foe on the enemy team with the highest Spd through its next action.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Chill Spd 2",
-      "effect": "At the start of each turn, inflicts Spd-5 on foe on the enemy team with the highest Spd through its next action.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Chill Spd 3",
-      "effect": "At the start of each turn, inflicts Spd-7 on foe on the enemy team with the highest Spd through its next action.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Chilling Seal",
-      "effect": "At the start of each turn, if unit's HP ≥ 50%, inflicts Atk/Spd-6 on foe on the enemy team with the lowest Def through its next action. (Skill cannot be inherited.)",
-      "exclusive": true,
-      "spCost": 300,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
       "name": "Close Counter",
@@ -39540,7 +38716,8 @@
         "Green Axe",
         "Red Breath",
         "Blue Breath",
-        "Green Breath"
+        "Green Breath",
+        "Colorless Breath"
       ],
       "type": "PASSIVE_A"
     },
@@ -39584,127 +38761,6 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Crusader's Ward",
-      "effect": "If unit receives consecutive attack from a foe 2 spaces away, damage from second attack onward reduced by 80%. (Skill cannot be inherited.)",
-      "exclusive": true,
-      "spCost": 300,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Dagger Valor 1",
-      "effect": "If unit survives and uses a dagger, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Dagger Valor 2",
-      "effect": "If unit survives, all dagger users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Dagger Valor 3",
-      "effect": "If unit survives, all dagger users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Daggerbreaker 1",
-      "effect": "If unit's HP ≥ 90% in combat against a dagger user, unit makes a follow-up attack and foe cannot.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Daggerbreaker 2",
-      "effect": "If unit's HP ≥ 70% in combat against a dagger user, unit makes a follow-up attack and foe cannot.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Daggerbreaker 3",
-      "effect": "If unit's HP ≥ 50% in combat against a dagger user, unit makes a follow-up attack and foe cannot.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
       "name": "Darting Blow 1",
       "effect": "Grants Spd+2 during combat if unit initiates the attack.",
       "exclusive": false,
@@ -39742,75 +38798,6 @@
         "Colorless Staff"
       ],
       "type": "PASSIVE_A"
-    },
-    {
-      "name": "Dazzling Staff 1",
-      "effect": "If unit has 100% HP at the start of combat, the enemy cannot counterattack.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Dazzling Staff 2",
-      "effect": "If unit has ≥ 50% HP at the start of combat, the enemy cannot counterattack.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Dazzling Staff 3",
-      "effect": "The enemy cannot counterattack.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger"
-      ],
-      "type": "PASSIVE_B"
     },
     {
       "name": "Death Blow 1",
@@ -39852,82 +38839,49 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Def Ploy 1",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Def-3 until the end of foe's next action.",
+      "name": "Triangle Adept 3",
+      "effect": "Gives Atk+20% if weapon-triangle advantage, Atk-20% if disadvantage.",
       "exclusive": false,
-      "spCost": 60,
+      "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Def Ploy 2",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Def-4 until the end of foe's next action.",
+      "name": "Triangle Adept 2",
+      "effect": "Gives Atk+15% if weapon-triangle advantage, Atk-15% if disadvantage.",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 100,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Def Ploy 3",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Def-5 until the end of foe's next action.",
+      "name": "Triangle Adept 1",
+      "effect": "Gives Atk+10% if weapon-triangle advantage, Atk-10% if disadvantage.",
       "exclusive": false,
-      "spCost": 240,
+      "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Def Tactic 1",
-      "effect": "At start of turn, grants Def+2 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Def Tactic 2",
-      "effect": "At start of turn, grants Def+4 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Def Tactic 3",
-      "effect": "At start of turn, grants Def+6 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
       "name": "Defense +1",
@@ -40125,58 +39079,14 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Desperation 1",
-      "effect": "If unit initiates combat with HP ≤ 25%, follow-up attacks occur immediately after unit's attack.",
+      "name": "Armored Blow 1",
+      "effect": "Grants Def+2 during combat if unit initiates the attack.",
       "exclusive": false,
       "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Desperation 2",
-      "effect": "If unit initiates combat with HP ≤ 50%, follow-up attacks occur immediately after unit's attack.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Desperation 3",
-      "effect": "If unit initiates combat with HP ≤ 75%, follow-up attacks occur immediately after unit's attack.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Distant Counter",
-      "effect": "Enables unit to counterattack regardless of distance to attacker.",
-      "exclusive": false,
-      "spCost": 300,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
         "Colorless Staff"
       ],
       "type": "PASSIVE_A"
@@ -40221,165 +39131,56 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Drag Back",
-      "effect": "If unit initiates attack, the unit moves 1 space away after combat. Foe moves into unit's previous space.",
+      "name": "Swift Strike 2",
+      "effect": "If unit initiates combat, unit granted Spd/Res+4 during battle.",
       "exclusive": false,
-      "spCost": 150,
+      "spCost": 240,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Drive Atk 1",
-      "effect": "Grants allies within 2 spaces Atk+2 during combat.",
+      "name": "Swift Strike 1",
+      "effect": "If unit initiates combat, unit granted Spd/Res+2 during battle.",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Drive Atk 2",
-      "effect": "Grants allies within 2 spaces Atk+3 during combat.",
+      "name": "Swift Sparrow 2",
+      "effect": "If unit initiates combat, unit granted Atk/Spd+4 during battle.",
       "exclusive": false,
       "spCost": 240,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Drive Def 1",
-      "effect": "Grants allies within 2 spaces Def+2 during combat.",
+      "name": "Swift Sparrow 1",
+      "effect": "If unit initiates combat, unit granted Atk/Spd+2 during battle.",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Drive Def 2",
-      "effect": "Grants allies within 2 spaces Def+3 during combat.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Drive Res 1",
-      "effect": "Grants allies within 2 spaces Res+2 during combat.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Drive Res 2",
-      "effect": "Grants allies within 2 spaces Res+3 during combat.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Drive Spd 1",
-      "effect": "Grants allies within 2 spaces Spd+2 during combat.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Drive Spd 2",
-      "effect": "Grants allies within 2 spaces Spd+3 during combat.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Dull Ranged 1",
-      "effect": "If unit's HP = 100% at start of combat and foe uses bow, dagger, magic, or staff, neutralizes foe's bonuses (from skills like Fortify, Rally, etc.) during combat.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Dull Ranged 2",
-      "effect": "If unit's HP ≥ 50% at start of combat and foe uses bow, dagger, magic, or staff, neutralizes foe's bonuses (from skills like Fortify, Rally, etc.) during combat.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Dull Ranged 3",
-      "effect": "If foe uses bow, dagger, magic, or staff, neutralizes foe's bonuses (from skills like Fortify, Rally, etc.) during combat.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_A"
     },
     {
       "name": "Earth Boost 1",
@@ -40419,84 +39220,6 @@
         ""
       ],
       "type": "PASSIVE_A"
-    },
-    {
-      "name": "Earth Dance 1",
-      "effect": "If Sing or Dance is used, target also granted Def+3.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Earth Dance 2",
-      "effect": "If Sing or Dance is used, target also granted Def+4.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Earth Dance 3",
-      "effect": "If Sing or Dance is used, target also granted Def+5.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Escape Route 1",
-      "effect": "Enables unit whose own HP is ≤ 30% to warp adjacent to any ally.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Escape Route 2",
-      "effect": "Enables unit whose own HP is ≤ 40% to warp adjacent to any ally.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Escape Route 3",
-      "effect": "Enables unit whose own HP is ≤ 50% to warp adjacent to any ally.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
     },
     {
       "name": "Fierce Stance 1",
@@ -40619,66 +39342,8 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "Flier Formation 1",
-      "effect": "If unit has 100% HP, unit can move to a space adjacent to a flier ally within 2 spaces.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Flier Formation 2",
-      "effect": "If unit has ≥ 50% HP, unit can move to a space adjacent to a flier ally within 2 spaces.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Flier Formation 3",
-      "effect": "Unit can move to a space adjacent to a flier ally within 2 spaces.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Follow-Up Ring",
-      "effect": "Unit makes a guaranteed follow-up attack when unit's HP ≥ 50% at start of combat. (Skill cannot be inherited.)",
-      "exclusive": true,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Fortify Armor",
-      "effect": "Grants adjacent armor allies Def/Res+6 through their next actions at the start of each turn.",
+      "name": "Svalinn Shield",
+      "effect": "Neutralizes \"effective against armored\" bonuses.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
@@ -40689,39 +39354,76 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Fortify Cavalry",
-      "effect": "Grants adjacent cavalry allies Def/Res+6 through their next actions at the start of each turn.",
+      "name": "Sturdy Stance 2",
+      "effect": "Grants Atk/Def+4 during combat when this unit is attacked.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Sturdy Stance 1",
+      "effect": "Grants Atk/Def+2 during combat when this unit is attacked.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Sturdy Blow 2",
+      "effect": "Grants Atk/Def+4 during combat if unit initiates combat.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Sturdy Blow 1",
+      "effect": "Grants Atk/Def+2 during combat if unit initiates combat.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Steady Stance 3",
+      "effect": "Grants Def+6 during combat when this unit is attacked.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Fortify Def 1",
-      "effect": "Grants adjacent allies Def+2 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Fortify Def 2",
-      "effect": "Grants adjacent allies Def+3 through their next actions at the start of each turn.",
+      "name": "Steady Stance 2",
+      "effect": "Grants Def+4 during combat when this unit is attacked.",
       "exclusive": false,
       "spCost": 100,
       "movementRestriction": [
@@ -40730,33 +39432,31 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Fortify Def 3",
-      "effect": "Grants adjacent allies Def+4 through their next actions at the start of each turn.",
+      "name": "Steady Stance 1",
+      "effect": "Grants Def+2 during combat when this unit is attacked.",
       "exclusive": false,
-      "spCost": 200,
+      "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Fortify Dragons",
-      "effect": "Grants adjacent Dragon allies Def/Res+6 through their next actions at the start of each turn.",
+      "name": "Steady Breath",
+      "effect": "If attacked, unit granted Def+4 during combat; also gains Special cooldown charge +1. (If using other similar skill, only highest value applied.)",
       "exclusive": false,
-      "spCost": 200,
+      "spCost": 240,
       "movementRestriction": [
-        ""
+        "Cavalry",
+        "Flying"
       ],
       "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
         "Red Tome",
         "Blue Tome",
         "Green Tome",
@@ -40764,61 +39464,20 @@
         "Colorless Dagger",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
-      "name": "Fortify Fliers",
-      "effect": "Grants adjacent flying allies Def/Res+6 through their next actions at the start of each turn.",
+      "name": "Steady Blow 2",
+      "effect": "If unit initiates combat, unit granted Spd/Def+4 during battle.",
       "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Fortify Res 1",
-      "effect": "Grants adjacent allies Res+2 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 50,
+      "spCost": 240,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Fortify Res 2",
-      "effect": "Grants adjacent allies Res+3 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Fortify Res 3",
-      "effect": "Grants adjacent allies Res+4 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_A"
     },
     {
       "name": "Fortress Def 1",
@@ -40938,32 +39597,1204 @@
       "type": "PASSIVE_A"
     },
     {
-      "name": "G Tome Valor 1",
-      "effect": "If unit survives and uses a green tome, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "name": "Steady Blow 1",
+      "effect": "If unit initiates combat, unit granted Spd/Def+2 during battle.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Grani's Shield",
+      "effect": "Neutralizes \"effective against cavalry\" bonuses.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Heavy Blade 1",
+      "effect": "If unit's Atk - foe's Atk ≥ 5, unit gains Special cooldown charge +1 per attack. (If using other similar skill, only highest value applied.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Heavy Blade 2",
+      "effect": "If unit's Atk - foe's Atk ≥ 3, unit gains Special cooldown charge +1 per attack. (If using other similar skill, only highest value applied.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Heavy Blade 3",
+      "effect": "If unit's Atk - foe's Atk ≥ 1, unit gains Special cooldown charge +1 per attack. (If using other similar skill, only highest value applied.)",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP +3",
+      "effect": "Grants +3 to max HP.",
+      "exclusive": false,
+      "spCost": 40,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP +4",
+      "effect": "Grants +4 to max HP.",
+      "exclusive": false,
+      "spCost": 80,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP +5",
+      "effect": "Grants +5 to max HP.",
+      "exclusive": false,
+      "spCost": 160,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP/Atk 1",
+      "effect": "Grants HP+3, Atk+1.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP/Atk 2",
+      "effect": "Grants HP+4, Atk+2.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP/Def 1",
+      "effect": "Grants HP+3, Def+1.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP/Res 1",
+      "effect": "Grants HP+3, Res+1.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP/Res 2",
+      "effect": "Grants HP+4, Res+2.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP/Spd 1",
+      "effect": "Grants HP+3, Spd+1.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "HP/Spd 2",
+      "effect": "Grants HP+4, Spd+2.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Iote's Shield",
+      "effect": "Neutralizes \"effective against fliers\" bonuses.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Speed +3",
+      "effect": "Grants Spd+3.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Life and Death 1",
+      "effect": "Grants Atk/Spd+3. Inflicts Def/Res-3.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Life and Death 2",
+      "effect": "Grants Atk/Spd+4. Inflicts Def/Res-4.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Life and Death 3",
+      "effect": "Grants Atk/Spd+5. Inflicts Def/Res-5.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Mirror Stance 1",
+      "effect": "Grants Atk/Res+2 during combat when this unit is attacked.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Mirror Stance 2",
+      "effect": "Grants Atk/Res+4 during combat when this unit is attacked.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Mirror Strike 1",
+      "effect": "Grants Atk/Res+2 during combat if unit initiates combat.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Mirror Strike 2",
+      "effect": "Grants Atk/Res+4 during combat if unit initiates combat.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Speed +2",
+      "effect": "Grants Spd+2.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Speed +1",
+      "effect": "Grants Spd+1.",
       "exclusive": false,
       "spCost": 30,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Spd/Res 2",
+      "effect": "Grants Spd/Res+2.",
+      "exclusive": false,
+      "spCost": 160,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Spd/Res 1",
+      "effect": "Grants Spd/Res+1.",
+      "exclusive": false,
+      "spCost": 80,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Spd/Def Bond 3",
+      "effect": "Grants Spd/Def+5 to this unit during combat if unit is adjacent to an ally.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Spd/Def Bond 2",
+      "effect": "Grants Spd/Def+4 to this unit during combat if unit is adjacent to an ally.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Spd/Def Bond 1",
+      "effect": "Grants Spd/Def+3 to this unit during combat if unit is adjacent to an ally.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Spd/Def 2",
+      "effect": "Grants Spd/Def+2.",
+      "exclusive": false,
+      "spCost": 160,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Spd/Def 1",
+      "effect": "Grants Spd/Def+1.",
+      "exclusive": false,
+      "spCost": 80,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Resistance +1",
+      "effect": "Grants Res+1.",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Resistance +2",
+      "effect": "Grants Res+2.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Resistance +3",
+      "effect": "Grants Res+3.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_A"
+    },
+    {
+      "name": "Wings of Mercy 3",
+      "effect": "Enables unit to warp adjacent to any ally with HP ≤ 50%.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Wings of Mercy 2",
+      "effect": "Enables unit to warp adjacent to any ally with HP ≤ 40%.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Watersweep 3",
+      "effect": "If unit initiates attack, no follow-up occurs. Against foe with magic, staff or dragonstone, if unit’s Spd - foe’s Spd ≥ 1, foe can’t counterattack.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Drag Back",
+      "effect": "If unit initiates attack, the unit moves 1 space away after combat. Foe moves into unit's previous space.",
+      "exclusive": false,
+      "spCost": 150,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
         "Red Tome",
         "Blue Tome",
         "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
         "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "G Tome Valor 2",
-      "effect": "If unit survives, all green tome users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "name": "Torrent Dance 1",
+      "effect": "If Sing or Dance is used, target also granted Res+3.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Swordbreaker 3",
+      "effect": "If unit's HP ≥ 50% in combat against a sword user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Green Axe",
+        "Green Tome",
+        "Green Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Swordbreaker 2",
+      "effect": "If unit's HP ≥ 70% in combat against a sword user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Green Axe",
+        "Green Tome",
+        "Green Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Swordbreaker 1",
+      "effect": "If unit's HP ≥ 90% in combat against a sword user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Green Axe",
+        "Green Tome",
+        "Green Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Watersweep 2",
+      "effect": "If unit initiates attack, no follow-up occurs. Against foe with magic, staff or dragonstone, if unit’s Spd - foe’s Spd ≥ 3, foe can’t counterattack.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Axebreaker 1",
+      "effect": "If unit's HP ≥ 90% in combat against an axe user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Blue Lance",
+        "Blue Tome",
+        "Blue Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Axebreaker 2",
+      "effect": "If unit's HP ≥ 70% in combat against an axe user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Blue Lance",
+        "Blue Tome",
+        "Blue Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Axebreaker 3",
+      "effect": "If unit's HP ≥ 50% in combat against an axe user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Blue Lance",
+        "Blue Tome",
+        "Blue Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Dull Ranged 1",
+      "effect": "If unit's HP = 100% at start of combat and foe uses bow, dagger, magic, or staff, neutralizes foe's bonuses (from skills like Fortify, Rally, etc.) during combat.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Dull Ranged 2",
+      "effect": "If unit's HP ≥ 50% at start of combat and foe uses bow, dagger, magic, or staff, neutralizes foe's bonuses (from skills like Fortify, Rally, etc.) during combat.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Dull Ranged 3",
+      "effect": "If foe uses bow, dagger, magic, or staff, neutralizes foe's bonuses (from skills like Fortify, Rally, etc.) during combat.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Watersweep 1",
+      "effect": "If unit initiates attack, no follow-up occurs. Against foe with magic, staff or dragonstone, if unit’s Spd - foe’s Spd ≥ 5, foe can’t counterattack.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Wings of Mercy 1",
+      "effect": "Enables unit to warp adjacent to any ally with HP ≤ 30%.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Windsweep 3",
+      "effect": "If unit initiates attack, no follow-up occurs. Against foe with sword, lance, axe, bow, or dagger, if unit’s Spd - foe’s Spd ≥ 1, foe can’t counterattack.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Earth Dance 1",
+      "effect": "If Sing or Dance is used, target also granted Def+3.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Earth Dance 2",
+      "effect": "If Sing or Dance is used, target also granted Def+4.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Earth Dance 3",
+      "effect": "If Sing or Dance is used, target also granted Def+5.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Escape Route 1",
+      "effect": "Enables unit whose own HP is ≤ 30% to warp adjacent to any ally.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Escape Route 2",
+      "effect": "Enables unit whose own HP is ≤ 40% to warp adjacent to any ally.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Escape Route 3",
+      "effect": "Enables unit whose own HP is ≤ 50% to warp adjacent to any ally.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Cancel Affinity 1",
+      "effect": "Any weapon triangle affinity granted by unit's skills is negated. Also negates any weapon triangle affinity granted by foe's skills.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Cancel Affinity 2",
+      "effect": "Any weapon triangle affinity granted by unit's skills is negated. If affinity disadvantage exists, weapon triangle affinity granted by foe's skills is negated.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Cancel Affinity 3",
+      "effect": "Any weapon triangle affinity granted by unit's skills is negated. If affinity disadvantage exists, weapon triangle affinity granted by foe's skills is reversed.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Chill Def 1",
+      "effect": "At the start of each turn, inflicts Def-3 on foe on the enemy team with the highest Def through its next action.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Chill Def 2",
+      "effect": "At the start of each turn, inflicts Def-5 on foe on the enemy team with the highest Def through its next action.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Chill Def 3",
+      "effect": "At the start of each turn, inflicts Def-7 on foe on the enemy team with the highest Def through its next action.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Chill Spd 1",
+      "effect": "At the start of each turn, inflicts Spd-3 on foe on the enemy team with the highest Spd through its next action.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Chill Spd 2",
+      "effect": "At the start of each turn, inflicts Spd-5 on foe on the enemy team with the highest Spd through its next action.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Chill Spd 3",
+      "effect": "At the start of each turn, inflicts Spd-7 on foe on the enemy team with the highest Spd through its next action.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Flier Formation 1",
+      "effect": "If unit has 100% HP, unit can move to a space adjacent to a flier ally within 2 spaces.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Flier Formation 2",
+      "effect": "If unit has ≥ 50% HP, unit can move to a space adjacent to a flier ally within 2 spaces.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Flier Formation 3",
+      "effect": "Unit can move to a space adjacent to a flier ally within 2 spaces.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Follow-Up Ring",
+      "effect": "Unit makes a guaranteed follow-up attack when unit's HP ≥ 50% at start of combat. (Skill cannot be inherited.)",
+      "exclusive": true,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Chilling Seal",
+      "effect": "At the start of each turn, if unit's HP ≥ 50%, inflicts Atk/Spd-6 on foe on the enemy team with the lowest Def through its next action. (Skill cannot be inherited.)",
+      "exclusive": true,
+      "spCost": 300,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Windsweep 2",
+      "effect": "If unit initiates attack, no follow-up occurs. Against foe with sword, lance, axe, bow, or dagger, if unit’s Spd - foe’s Spd ≥ 3, foe can’t counterattack.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Wary Fighter 3",
+      "effect": "Prevents follow-up attacks in combat from unit and foes if unit's HP ≥ 50%.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Wary Fighter 2",
+      "effect": "Prevents follow-up attacks in combat from unit and foes if unit's HP ≥ 70%.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "B Tomebreaker 1",
+      "effect": "If unit's HP ≥ 90% in combat against a blue tome user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Red Tome",
+        "Red Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Crusader's Ward",
+      "effect": "If unit receives consecutive attack from a foe 2 spaces away, damage from second attack onward reduced by 80%. (Skill cannot be inherited.)",
+      "exclusive": true,
+      "spCost": 300,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Vengeful Fighter 3",
+      "effect": "If unit's HP ≥ 50% and foe initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Vengeful Fighter 2",
+      "effect": "If unit's HP ≥ 70% and foe initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Vengeful Fighter 1",
+      "effect": "If unit's HP ≥ 90% and foe initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Daggerbreaker 1",
+      "effect": "If unit's HP ≥ 90% in combat against a dagger user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Daggerbreaker 2",
+      "effect": "If unit's HP ≥ 70% in combat against a dagger user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Daggerbreaker 3",
+      "effect": "If unit's HP ≥ 50% in combat against a dagger user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "B Tomebreaker 2",
+      "effect": "If unit's HP ≥ 70% in combat against a blue tome user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Red Tome",
+        "Red Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "B Tomebreaker 3",
+      "effect": "If unit's HP ≥ 50% in combat against a blue tome user, unit makes a follow-up attack and foe cannot.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Red Tome",
+        "Red Breath"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Beorc's Blessing",
+      "effect": "If foe is cavalry or flier type, foe's bonuses (from skills like Fortify, Rally, etc.) are nullified during combat. (Skill cannot be inherited.)",
+      "exclusive": true,
+      "spCost": 300,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Dazzling Staff 1",
+      "effect": "If unit has 100% HP at the start of combat, the enemy cannot counterattack.",
       "exclusive": false,
       "spCost": 60,
       "movementRestriction": [
@@ -40979,15 +40810,15 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
+        "Colorless Dagger"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "G Tome Valor 3",
-      "effect": "If unit survives, all green tome users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "name": "Dazzling Staff 2",
+      "effect": "If unit has ≥ 50% HP at the start of combat, the enemy cannot counterattack.",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
@@ -41003,11 +40834,61 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
-        "Colorless Dagger",
+        "Colorless Dagger"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Dazzling Staff 3",
+      "effect": "The enemy cannot counterattack.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Blaze Dance 1",
+      "effect": "If Sing or Dance is used, target also granted Atk+2.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
         "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Blaze Dance 2",
+      "effect": "If Sing or Dance is used, target also granted Atk+3.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
     },
     {
       "name": "G Tomebreaker 1",
@@ -41120,64 +41001,17 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Goad Armor",
-      "effect": "Grants armored allies within 2 spaces Spd/Atk+4 during combat.",
+      "name": "Blaze Dance 3",
+      "effect": "If Sing or Dance is used, target also granted Atk+4.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Goad Cavalry",
-      "effect": "Grants cavalry allies within 2 spaces Spd/Atk+4 during combat.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Flying"
-      ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Goad Fliers",
-      "effect": "Grants flying allies within 2 spaces Spd/Atk+4 during combat.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Grani's Shield",
-      "effect": "Neutralizes \"effective against cavalry\" bonuses.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
     },
     {
       "name": "Guard 1",
@@ -41219,88 +41053,43 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Guidance 1",
-      "effect": "If unit has 100% HP, infantry and armored allies within 2 spaces can move to a space adjacent to unit.",
+      "name": "Vantage 3",
+      "effect": "Unit counterattacks first when attacked at HP ≤ 75%.",
       "exclusive": false,
-      "spCost": 60,
+      "spCost": 200,
       "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
+        ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Guidance 2",
-      "effect": "If unit has ≥ 50% HP, infantry and armored allies within 2 spaces can move to a space adjacent to unit.",
+      "name": "Vantage 2",
+      "effect": "Unit counterattacks first when attacked at HP ≤ 50%.",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 100,
       "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
+        ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Guidance 3",
-      "effect": "Infantry and armored allies within 2 spaces can move to a space adjacent to unit.",
+      "name": "Vantage 1",
+      "effect": "Unit counterattacks first when attacked at HP ≤ 25%.",
       "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Heavy Blade 1",
-      "effect": "If unit's Atk - foe's Atk ≥ 5, unit gains Special cooldown charge +1 per attack. (If using other similar skill, only highest value applied.)",
-      "exclusive": false,
-      "spCost": 60,
+      "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Heavy Blade 2",
-      "effect": "If unit's Atk - foe's Atk ≥ 3, unit gains Special cooldown charge +1 per attack. (If using other similar skill, only highest value applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
         ""
       ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Heavy Blade 3",
-      "effect": "If unit's Atk - foe's Atk ≥ 1, unit gains Special cooldown charge +1 per attack. (If using other similar skill, only highest value applied.)",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
     },
     {
       "name": "Hit and Run",
@@ -41321,10 +41110,10 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Hone Armor",
-      "effect": "Grants adjacent armored allies Atk/Spd+6 through their next actions at the start of each turn.",
+      "name": "Bold Fighter 1",
+      "effect": "If unit's HP = 100% and unit initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
       "exclusive": false,
-      "spCost": 200,
+      "spCost": 60,
       "movementRestriction": [
         "Infantry",
         "Cavalry",
@@ -41333,67 +41122,71 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Hone Atk 1",
-      "effect": "Grants adjacent allies Atk+2 through their next actions at the start of each turn.",
+      "name": "Bold Fighter 2",
+      "effect": "If unit's HP ≥ 50% and unit initiates combat, unit makes a guaranteed follow-up attack.<Br>Grants Special cooldown charge +1 per attack. (Does not stack.)",
       "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Hone Atk 2",
-      "effect": "Grants adjacent allies Atk+3 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Hone Atk 3",
-      "effect": "Grants adjacent allies Atk+4 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Hone Cavalry",
-      "effect": "Grants adjacent cavalry allies Atk/Spd+6 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 200,
+      "spCost": 120,
       "movementRestriction": [
         "Infantry",
-        "Armored",
+        "Cavalry",
         "Flying"
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Hone Dragons",
-      "effect": "Grants adjacent dragon allies Atk/Spd+6 through their next actions at the start of each turn.",
+      "name": "Bold Fighter 3",
+      "effect": "If unit initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
       "exclusive": false,
-      "spCost": 200,
+      "spCost": 240,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Wary Fighter 1",
+      "effect": "Prevents follow-up attacks in combat from unit and foes if unit's HP ≥ 90%.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Warp Powder",
+      "effect": "If unit's HP ≥ 80%, unit can move adjacent to any ally within 2 spaces. (Skill cannot be inherited.)",
+      "exclusive": true,
+      "spCost": 300,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Wrathful Staff 2",
+      "effect": "If unit has ≥ 50% HP at the start of combat, damage from their staff will be calculated the same as other weapons.",
+      "exclusive": false,
+      "spCost": 120,
       "movementRestriction": [
         ""
       ],
@@ -41404,270 +41197,88 @@
         "Red Tome",
         "Blue Tome",
         "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
+        "Colorless Dagger"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Hone Fliers",
-      "effect": "Grants adjacent flying allies Atk/Spd+6 through their next actions at the start of each turn.",
+      "name": "Wrathful Staff 3",
+      "effect": "Damage from unit's staff will be calculated the same as other weapons.",
       "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Hone Spd 1",
-      "effect": "Grants adjacent allies Spd+2 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 50,
+      "spCost": 240,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Hone Spd 2",
-      "effect": "Grants adjacent allies Spd+3 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Hone Spd 3",
-      "effect": "Grants adjacent allies Spd+4 through their next actions at the start of each turn.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "HP +3",
-      "effect": "Grants +3 to max HP.",
-      "exclusive": false,
-      "spCost": 40,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "HP +4",
-      "effect": "Grants +4 to max HP.",
-      "exclusive": false,
-      "spCost": 80,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "HP +5",
-      "effect": "Grants +5 to max HP.",
-      "exclusive": false,
-      "spCost": 160,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "HP Atk 1",
-      "effect": "Grants HP+3, Atk+1.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "HP Atk 2",
-      "effect": "Grants HP+4, Atk+2.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Armor March 1",
-      "effect": "If unit has 100% HP and an adjacent armored ally at start of turn, unit and any such allies can move 1 extra space. (That turn only; does not stack.)",
+      "name": "Wrathful Staff 1",
+      "effect": "If unit has 100% HP at the start of combat, damage from their staff will be calculated the same as other weapons.",
       "exclusive": false,
       "spCost": 60,
       "movementRestriction": [
-        "Infantry",
-        "Cavalry",
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Bowbreaker 1",
+      "effect": "If unit's HP ≥ 90% in combat against a colorless bow foe, unit makes a guaranteed follow-up attack and foe cannot make a follow-up attack.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
         "Flying"
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "HP Def 2",
-      "effect": "Grants HP+4, Def+2.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "HP Res 1",
-      "effect": "Grants HP+3, Res+1.",
+      "name": "Bowbreaker 2",
+      "effect": "If unit's HP ≥ 70% in combat against a colorless bow foe, unit makes a guaranteed follow-up attack and foe cannot make a follow-up attack.",
       "exclusive": false,
       "spCost": 100,
       "movementRestriction": [
-        ""
+        "Flying"
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "HP Res 2",
-      "effect": "Grants HP+4, Res+2.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "HP Spd 1",
-      "effect": "Grants HP+3, Spd+1.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "HP Spd 2",
-      "effect": "Grants HP+4, Spd+2.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Infantry Pulse 1",
-      "effect": "Special cooldown count-1 at start of turn 1 for any Infantry allies with at least 5 fewer HP than unit. (Effects will stack with similar skills.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        "Flying",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Infantry Pulse 2",
-      "effect": "Special cooldown count-1 at start of turn 1 for any Infantry allies with at least 3 fewer HP than unit. (Effects will stack with similar skills.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        "Flying",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Infantry Pulse 3",
-      "effect": "Special cooldown count-1 at start of turn 1 for any Infantry allies with at least 1 fewer HP than unit. (Effects will stack with similar skills.)",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Flying",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Iote's Shield",
-      "effect": "Neutralizes \"effective against fliers\" bonuses.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        "Infantry",
-        "Armored",
-        "Cavalry"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
     },
     {
       "name": "Knock Back",
@@ -41688,73 +41299,17 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Lance Valor 1",
-      "effect": "If unit survives and uses a lance, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "name": "Bowbreaker 3",
+      "effect": "If unit's HP ≥ 50% in combat against a colorless bow foe, unit makes a guaranteed follow-up attack and foe cannot make a follow-up attack.",
       "exclusive": false,
-      "spCost": 30,
+      "spCost": 200,
       "movementRestriction": [
-        ""
+        "Flying"
       ],
       "weaponRestriction": [
-        "Red Sword",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Lance Valor 2",
-      "effect": "If unit survives, all lance users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
         ""
       ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Lance Valor 3",
-      "effect": "If unit survives, all lance users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
       "name": "Lancebreaker 1",
@@ -41802,43 +41357,55 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Life and Death 1",
-      "effect": "Grants Atk/Spd+3. Inflicts Def/Res-3.",
+      "name": "Wrath 3",
+      "effect": "If unit's HP ≤ 75%, Special cooldown count-1 at start of turn if Special triggers by attacking. If Special triggers, +10 damage from Special.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Wrath 2",
+      "effect": "If unit's HP ≤ 50%, Special cooldown count-1 at start of turn if Special triggers by attacking. If Special triggers, +10 damage from Special.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Brash Assault 1",
+      "effect": "If unit initiates combat against a foe that can counter and unit's HP ≤ 30%, unit makes a guaranteed follow-up attack.",
       "exclusive": false,
       "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Life and Death 2",
-      "effect": "Grants Atk/Spd+4. Inflicts Def/Res-4.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
         ""
       ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Life and Death 3",
-      "effect": "Grants Atk/Spd+5. Inflicts Def/Res-5.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
     },
     {
       "name": "Live for Bounty",
@@ -41884,6 +41451,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger"
       ],
@@ -41907,6 +41475,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger"
       ],
@@ -41930,6 +41499,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger"
       ],
@@ -41954,56 +41524,43 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Mirror Stance 1",
-      "effect": "Grants Atk/Res+2 during combat when this unit is attacked.",
+      "name": "Brash Assault 2",
+      "effect": "If unit initiates combat against a foe that can counter and unit's HP ≤ 40%, unit makes a guaranteed follow-up attack.",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 100,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Mirror Stance 2",
-      "effect": "Grants Atk/Res+4 during combat when this unit is attacked.",
+      "name": "Brash Assault 3",
+      "effect": "If unit initiates combat against a foe that can counter and unit's HP ≤ 50%, unit makes a guaranteed follow-up attack.",
       "exclusive": false,
-      "spCost": 240,
+      "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Mirror Strike 1",
-      "effect": "Grants Atk/Res+2 during combat if unit initiates combat.",
+      "name": "Windsweep 1",
+      "effect": "If unit initiates attack, no follow-up occurs. Against foe with sword, lance, axe, bow, or dagger, if unit’s Spd - foe’s Spd ≥ 5, foe can’t counterattack.",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 60,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
         "Colorless Staff"
       ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Mirror Strike 2",
-      "effect": "Grants Atk/Res+4 during combat if unit initiates combat.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
     },
     {
       "name": "Obstruct 1",
@@ -42043,45 +41600,6 @@
         ""
       ],
       "type": "PASSIVE_B"
-    },
-    {
-      "name": "Panic Ploy 1",
-      "effect": "At start of turn, bonuses become penalties on all foes in cardinal directions with HP 5 or more lower than unit through foe's next action.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Panic Ploy 2",
-      "effect": "At start of turn, bonuses become penalties on all foes in cardinal directions with HP 3 or more lower than unit through foe's next action.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Panic Ploy 3",
-      "effect": "At start of turn, bonuses become penalties on all foes in cardinal directions with HP 1 or more lower than unit through foe's next action.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
     },
     {
       "name": "Pass 1",
@@ -42201,142 +41719,17 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "R Tome Exp. 1",
-      "effect": "If using red magic and unit survives combat, unit gets 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "name": "Desperation 1",
+      "effect": "If unit initiates combat with HP ≤ 25%, follow-up attacks occur immediately after unit's attack.",
       "exclusive": false,
-      "spCost": 30,
+      "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "R Tome Exp. 2",
-      "effect": "If unit survives combat, all red magic users on team get 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
         ""
       ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "R Tome Exp. 3",
-      "effect": "If unit survives combat, all red magic users on team get 2x EXP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "R Tome Valor 1",
-      "effect": "If unit survives and uses a red tome, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "R Tome Valor 2",
-      "effect": "If unit survives, all red tome users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "R Tome Valor 3",
-      "effect": "If unit survives, all red tome users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
       "name": "R Tomebreaker 1",
@@ -42436,121 +41829,145 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Res Ploy 1",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Res-3 until the end of foe's next action.",
-      "exclusive": false,
-      "spCost": 60,
+      "name": "Solar Brace",
+      "effect": "Restores 30% of damage dealt when Special triggers during combat. (Stacks with effects of skills like Sol.)",
+      "exclusive": true,
+      "spCost": 300,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Res Ploy 2",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Res-4 until the end of foe's next action.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Res Ploy 3",
-      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Res-5 until the end of foe's next action.",
+      "name": "Shield Pulse 3",
+      "effect": "If unit's Special triggers based on a foe's attack, Special cooldown count-2 at start of turn 1. Unit takes 5 less damage when Special triggers.",
       "exclusive": false,
       "spCost": 240,
       "movementRestriction": [
-        ""
+        "Cavalry",
+        "Flying"
       ],
       "weaponRestriction": [
-        ""
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Res Tactic 1",
-      "effect": "At start of turn, grants Res+2 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Res Tactic 2",
-      "effect": "At start of turn, grants Res+4 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
+      "name": "Shield Pulse 2",
+      "effect": "If unit's Special triggers based on a foe's attack, Special cooldown count-1 at start of turn 1. Unit takes 5 less damage when Special triggers.",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
-        ""
+        "Cavalry",
+        "Flying"
       ],
       "weaponRestriction": [
-        ""
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Res Tactic 3",
-      "effect": "At start of turn, grants Res+6 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_C"
-    },
-    {
-      "name": "Resistance +1",
-      "effect": "Grants Res+1.",
-      "exclusive": false,
-      "spCost": 30,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Resistance +2",
-      "effect": "Grants Res+2.",
+      "name": "Shield Pulse 1",
+      "effect": "If unit's Special triggers based on a foe's attack, Special cooldown count-1 at start of turn 1.",
       "exclusive": false,
       "spCost": 60,
       "movementRestriction": [
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Seal Spd 3",
+      "effect": "After combat, foe suffers Spd-7 through its next action.",
+      "exclusive": false,
+      "spCost": 160,
+      "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Resistance +3",
-      "effect": "Grants Res+3.",
+      "name": "Seal Spd 2",
+      "effect": "After combat, foe suffers Spd-5 through its next action.",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 80,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Desperation 2",
+      "effect": "If unit initiates combat with HP ≤ 50%, follow-up attacks occur immediately after unit's attack.",
+      "exclusive": false,
+      "spCost": 100,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Desperation 3",
+      "effect": "If unit initiates combat with HP ≤ 75%, follow-up attacks occur immediately after unit's attack.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_B"
+    },
+    {
+      "name": "Wrath 1",
+      "effect": "If unit's HP ≤ 25%, Special cooldown count-1 at start of turn if Special triggers by attacking. If Special triggers, +10 damage from Special.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_B"
     },
     {
       "name": "Sacae's Blessing",
@@ -42566,43 +41983,43 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Savage Blow 1",
-      "effect": "If unit initiates attack, foes within 2 spaces of target take 3 damage after combat.",
+      "name": "Seal Spd 1",
+      "effect": "After combat, foe suffers Spd-3 through its next action.",
       "exclusive": false,
-      "spCost": 50,
+      "spCost": 40,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Savage Blow 2",
-      "effect": "If unit initiates attack, foes within 2 spaces of target take 5 damage after combat.",
+      "name": "Seal Res 3",
+      "effect": "After combat, foe suffers Res-7 through its next action.",
       "exclusive": false,
-      "spCost": 100,
+      "spCost": 160,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
-      "name": "Savage Blow 3",
-      "effect": "If unit initiates attack, foes within 2 spaces of target take 7 damage after combat.",
+      "name": "Seal Res 2",
+      "effect": "After combat, foe suffers Res-5 through its next action.",
       "exclusive": false,
-      "spCost": 200,
+      "spCost": 80,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_C"
+      "type": "PASSIVE_B"
     },
     {
       "name": "Seal Atk 1",
@@ -42644,7 +42061,7 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Seal Atk Def 1",
+      "name": "Seal Atk/Def 1",
       "effect": "After combat, inflicts Atk/Def-3 on foe through its next action.",
       "exclusive": false,
       "spCost": 100,
@@ -42657,7 +42074,7 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Seal Atk Def 2",
+      "name": "Seal Atk/Def 2",
       "effect": "After combat, inflicts Atk/Def-5 on foe through its next action.",
       "exclusive": false,
       "spCost": 200,
@@ -42670,7 +42087,7 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Seal Atk Spd 1",
+      "name": "Seal Atk/Spd 1",
       "effect": "After combat, inflicts Atk/Spd-3 on foe through its next action.",
       "exclusive": false,
       "spCost": 100,
@@ -42683,7 +42100,7 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Seal Atk Spd 2",
+      "name": "Seal Atk/Spd 2",
       "effect": "After combat, inflicts Atk/Spd-5 on foe through its next action.",
       "exclusive": false,
       "spCost": 200,
@@ -42748,195 +42165,47 @@
       "type": "PASSIVE_B"
     },
     {
-      "name": "Seal Res 2",
-      "effect": "After combat, foe suffers Res-5 through its next action.",
+      "name": "Fortify Def 2",
+      "effect": "Grants adjacent allies Def+3 through their next actions at the start of each turn.",
       "exclusive": false,
-      "spCost": 80,
+      "spCost": 100,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Seal Res 3",
-      "effect": "After combat, foe suffers Res-7 through its next action.",
+      "name": "Savage Blow 3",
+      "effect": "If unit initiates attack, foes within 2 spaces of target take 7 damage after combat.",
       "exclusive": false,
-      "spCost": 160,
+      "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Seal Spd 1",
-      "effect": "After combat, foe suffers Spd-3 through its next action.",
+      "name": "Savage Blow 1",
+      "effect": "If unit initiates attack, foes within 2 spaces of target take 3 damage after combat.",
       "exclusive": false,
-      "spCost": 40,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Seal Spd 2",
-      "effect": "After combat, foe suffers Spd-5 through its next action.",
-      "exclusive": false,
-      "spCost": 80,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Seal Spd 3",
-      "effect": "After combat, foe suffers Spd-7 through its next action.",
-      "exclusive": false,
-      "spCost": 160,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Shield Pulse 1",
-      "effect": "If unit's Special triggers based on a foe's attack, Special cooldown count-1 at start of turn 1.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Shield Pulse 2",
-      "effect": "If unit's Special triggers based on a foe's attack, Special cooldown count-1 at start of turn 1. Unit takes 5 less damage when Special triggers.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Shield Pulse 3",
-      "effect": "If unit's Special triggers based on a foe's attack, Special cooldown count-2 at start of turn 1. Unit takes 5 less damage when Special triggers.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Solar Brace",
-      "effect": "Restores 30% of damage dealt when Special triggers during combat. (Stacks with effects of skills like Sol.)",
-      "exclusive": true,
-      "spCost": 300,
+      "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Spd Def 1",
-      "effect": "Grants Spd/Def+1.",
-      "exclusive": false,
-      "spCost": 80,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Spd Def 2",
-      "effect": "Grants Spd/Def+2.",
-      "exclusive": false,
-      "spCost": 160,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Spd Def Bond 1",
-      "effect": "Grants Spd/Def+3 to this unit during combat if unit is adjacent to an ally.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Spd Def Bond 2",
-      "effect": "Grants Spd/Def+4 to this unit during combat if unit is adjacent to an ally.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Spd Def Bond 3",
-      "effect": "Grants Spd/Def+5 to this unit during combat if unit is adjacent to an ally.",
+      "name": "Res Tactic 3",
+      "effect": "At start of turn, grants Res+6 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
       "exclusive": false,
       "spCost": 240,
       "movementRestriction": [
@@ -42945,7 +42214,72 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Res Tactic 2",
+      "effect": "At start of turn, grants Res+4 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Res Tactic 1",
+      "effect": "At start of turn, grants Res+2 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Res Ploy 3",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Res-5 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Res Ploy 2",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Res-4 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Res Ploy 1",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Res-3 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
     },
     {
       "name": "Spd Ploy 1",
@@ -42987,32 +42321,6 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Spd Res 1",
-      "effect": "Grants Spd/Res+1.",
-      "exclusive": false,
-      "spCost": 80,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Spd Res 2",
-      "effect": "Grants Spd/Res+2.",
-      "exclusive": false,
-      "spCost": 160,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
       "name": "Spd Smoke 1",
       "effect": "After combat, inflicts Spd-3 on foes within 2 spaces of target through their next actions.",
       "exclusive": false,
@@ -43052,34 +42360,165 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Speed +1",
-      "effect": "Grants Spd+1.",
+      "name": "R Tome Valor 3",
+      "effect": "If unit survives, all red tome users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
       "exclusive": false,
-      "spCost": 30,
+      "spCost": 120,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Speed +2",
-      "effect": "Grants Spd+2.",
+      "name": "R Tome Valor 2",
+      "effect": "If unit survives, all red tome users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
       "exclusive": false,
       "spCost": 60,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Speed +3",
-      "effect": "Grants Spd+3.",
+      "name": "R Tome Valor 1",
+      "effect": "If unit survives and uses a red tome, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "R Tome Exp. 3",
+      "effect": "If unit survives combat, all red magic users on team get 2x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "R Tome Exp. 2",
+      "effect": "If unit survives combat, all red magic users on team get 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "R Tome Exp. 1",
+      "effect": "If using red magic and unit survives combat, unit gets 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Panic Ploy 3",
+      "effect": "At start of turn, bonuses become penalties on all foes in cardinal directions with HP 1 or more lower than unit through foe's next action.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Panic Ploy 2",
+      "effect": "At start of turn, bonuses become penalties on all foes in cardinal directions with HP 3 or more lower than unit through foe's next action.",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
@@ -43088,7 +42527,44 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Panic Ploy 1",
+      "effect": "At start of turn, bonuses become penalties on all foes in cardinal directions with HP 5 or more lower than unit through foe's next action.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Lance Valor 3",
+      "effect": "If unit survives, all lance users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
     },
     {
       "name": "Spur Atk 1",
@@ -43130,7 +42606,7 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Spur Atk Spd 1",
+      "name": "Spur Atk/Spd 1",
       "effect": "Grants adjacent allies Atk/Spd +2 during combat.",
       "exclusive": false,
       "spCost": 120,
@@ -43143,7 +42619,7 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Spur Atk Spd 2",
+      "name": "Spur Atk/Spd 2",
       "effect": "Grants adjacent allies Atk/Spd +3 during combat.",
       "exclusive": false,
       "spCost": 240,
@@ -43195,7 +42671,7 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Spur Def Res 1",
+      "name": "Spur Def/Res 1",
       "effect": "Grants adjacent allies Def/Res +2 during combat",
       "exclusive": false,
       "spCost": 120,
@@ -43208,7 +42684,7 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Spur Def Res 2",
+      "name": "Spur Def/Res 2",
       "effect": "Grants adjacent allies Def/Res +3 during combat.",
       "exclusive": false,
       "spCost": 240,
@@ -43299,7 +42775,7 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Spur Spd Def 1",
+      "name": "Spur Spd/Def 1",
       "effect": "Grants adjacent allies Spd/Def +2 during combat",
       "exclusive": false,
       "spCost": 120,
@@ -43312,7 +42788,7 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Spur Spd Def 2",
+      "name": "Spur Spd/Def 2",
       "effect": "Grants adjacent allies Spd/Def +3 during combat.",
       "exclusive": false,
       "spCost": 240,
@@ -43325,79 +42801,116 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Steady Blow 1",
-      "effect": "If unit initiates combat, unit granted Spd/Def+2 during battle.",
+      "name": "Lance Valor 2",
+      "effect": "If unit survives, all lance users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 60,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Steady Blow 2",
-      "effect": "If unit initiates combat, unit granted Spd/Def+4 during battle.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Steady Breath",
-      "effect": "If attacked, unit granted Def+4 during combat; also gains Special cooldown charge +1. (If using other similar skill, only highest value applied.)",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
+        "Red Sword",
+        "Green Axe",
         "Red Tome",
         "Blue Tome",
         "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Steady Stance 1",
-      "effect": "Grants Def+2 during combat when this unit is attacked.",
+      "name": "Lance Valor 1",
+      "effect": "If unit survives and uses a lance, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
       "exclusive": false,
-      "spCost": 50,
+      "spCost": 30,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        ""
+        "Red Sword",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Steady Stance 2",
-      "effect": "Grants Def+4 during combat when this unit is attacked.",
+      "name": "Infantry Pulse 3",
+      "effect": "Special cooldown count-1 at start of turn 1 for any Infantry allies with at least 1 fewer HP than unit. (Effects will stack with similar skills.)",
       "exclusive": false,
-      "spCost": 100,
+      "spCost": 240,
       "movementRestriction": [
-        ""
+        "Flying",
+        "Armored",
+        "Cavalry"
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Steady Stance 3",
-      "effect": "Grants Def+6 during combat when this unit is attacked.",
+      "name": "Infantry Pulse 2",
+      "effect": "Special cooldown count-1 at start of turn 1 for any Infantry allies with at least 3 fewer HP than unit. (Effects will stack with similar skills.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        "Flying",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Infantry Pulse 1",
+      "effect": "Special cooldown count-1 at start of turn 1 for any Infantry allies with at least 5 fewer HP than unit. (Effects will stack with similar skills.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        "Flying",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Armor March 2",
+      "effect": "If unit has ≥ 50% HP and an adjacent armored ally at start of turn, unit and any such allies can move 1 extra space. (That turn only; does not stack.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Hone Spd 3",
+      "effect": "Grants adjacent allies Spd+4 through their next actions at the start of each turn.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
@@ -43406,63 +42919,127 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Sturdy Blow 1",
-      "effect": "Grants Atk/Def+2 during combat if unit initiates combat.",
+      "name": "Hone Spd 2",
+      "effect": "Grants adjacent allies Spd+3 through their next actions at the start of each turn.",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 100,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Sturdy Blow 2",
-      "effect": "Grants Atk/Def+4 during combat if unit initiates combat.",
+      "name": "Hone Spd 1",
+      "effect": "Grants adjacent allies Spd+2 through their next actions at the start of each turn.",
       "exclusive": false,
-      "spCost": 240,
+      "spCost": 50,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Sturdy Stance 1",
-      "effect": "Grants Atk/Def+2 during combat when this unit is attacked.",
+      "name": "Hone Fliers",
+      "effect": "Grants adjacent flying allies Atk/Spd+6 through their next actions at the start of each turn.",
       "exclusive": false,
-      "spCost": 120,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Hone Dragons",
+      "effect": "Grants adjacent dragon allies Atk/Spd+6 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Sturdy Stance 2",
-      "effect": "Grants Atk/Def+4 during combat when this unit is attacked.",
+      "name": "Hone Cavalry",
+      "effect": "Grants adjacent cavalry allies Atk/Spd+6 through their next actions at the start of each turn.",
       "exclusive": false,
-      "spCost": 240,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Hone Atk 3",
+      "effect": "Grants adjacent allies Atk+4 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 200,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Svalinn Shield",
-      "effect": "Neutralizes \"effective against armored\" bonuses.",
+      "name": "Hone Atk 2",
+      "effect": "Grants adjacent allies Atk+3 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Hone Atk 1",
+      "effect": "Grants adjacent allies Atk+2 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Hone Armor",
+      "effect": "Grants adjacent armored allies Atk/Spd+6 through their next actions at the start of each turn.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
@@ -43473,59 +43050,368 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Swift Sparrow 1",
-      "effect": "If unit initiates combat, unit granted Atk/Spd+2 during battle.",
+      "name": "Guidance 3",
+      "effect": "Infantry and armored allies within 2 spaces can move to a space adjacent to unit.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Guidance 2",
+      "effect": "If unit has ≥ 50% HP, infantry and armored allies within 2 spaces can move to a space adjacent to unit.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Guidance 1",
+      "effect": "If unit has 100% HP, infantry and armored allies within 2 spaces can move to a space adjacent to unit.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Goad Fliers",
+      "effect": "Grants flying allies within 2 spaces Spd/Atk+4 during combat.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Goad Cavalry",
+      "effect": "Grants cavalry allies within 2 spaces Spd/Atk+4 during combat.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Goad Armor",
+      "effect": "Grants armored allies within 2 spaces Spd/Atk+4 during combat.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "G Tome Valor 3",
+      "effect": "If unit survives, all green tome users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
         "Colorless Staff"
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Swift Sparrow 2",
-      "effect": "If unit initiates combat, unit granted Atk/Spd+4 during battle.",
+      "name": "G Tome Valor 2",
+      "effect": "If unit survives, all green tome users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "G Tome Valor 1",
+      "effect": "If unit survives and uses a green tome, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Res 3",
+      "effect": "Grants adjacent allies Res+4 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Res 2",
+      "effect": "Grants adjacent allies Res+3 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Res 1",
+      "effect": "Grants adjacent allies Res+2 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Fliers",
+      "effect": "Grants adjacent flying allies Def/Res+6 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Cavalry"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Dragons",
+      "effect": "Grants adjacent Dragon allies Def/Res+6 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Def 3",
+      "effect": "Grants adjacent allies Def+4 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Savage Blow 2",
+      "effect": "If unit initiates attack, foes within 2 spaces of target take 5 damage after combat.",
+      "exclusive": false,
+      "spCost": 100,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Def 1",
+      "effect": "Grants adjacent allies Def+2 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 50,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Cavalry",
+      "effect": "Grants adjacent cavalry allies Def/Res+6 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Armored",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Fortify Armor",
+      "effect": "Grants adjacent armor allies Def/Res+6 through their next actions at the start of each turn.",
+      "exclusive": false,
+      "spCost": 200,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Drive Spd 2",
+      "effect": "Grants allies within 2 spaces Spd+3 during combat.",
       "exclusive": false,
       "spCost": 240,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Swift Strike 1",
-      "effect": "If unit initiates combat, unit granted Spd/Res+2 during battle.",
+      "name": "Drive Spd 1",
+      "effect": "Grants allies within 2 spaces Spd+2 during combat.",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Swift Strike 2",
-      "effect": "If unit initiates combat, unit granted Spd/Res+4 during battle.",
+      "name": "Drive Res 2",
+      "effect": "Grants allies within 2 spaces Res+3 during combat.",
       "exclusive": false,
       "spCost": 240,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Colorless Staff"
+        ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Drive Res 1",
+      "effect": "Grants allies within 2 spaces Res+2 during combat.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
     },
     {
       "name": "Sword Exp. 1",
@@ -43544,6 +43430,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
@@ -43567,6 +43454,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
@@ -43590,6 +43478,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
@@ -43613,6 +43502,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
@@ -43636,6 +43526,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
@@ -43659,6 +43550,7 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
+        "Colorless Breath",
         "Colorless Bow",
         "Colorless Dagger",
         "Colorless Staff"
@@ -43666,49 +43558,43 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Swordbreaker 1",
-      "effect": "If unit's HP ≥ 90% in combat against a sword user, unit makes a follow-up attack and foe cannot.",
+      "name": "Drive Def 2",
+      "effect": "Grants allies within 2 spaces Def+3 during combat.",
       "exclusive": false,
-      "spCost": 50,
+      "spCost": 240,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Green Axe",
-        "Green Tome",
-        "Green Breath"
+        ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Swordbreaker 2",
-      "effect": "If unit's HP ≥ 70% in combat against a sword user, unit makes a follow-up attack and foe cannot.",
+      "name": "Drive Def 1",
+      "effect": "Grants allies within 2 spaces Def+2 during combat.",
       "exclusive": false,
-      "spCost": 100,
+      "spCost": 120,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Green Axe",
-        "Green Tome",
-        "Green Breath"
+        ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Swordbreaker 3",
-      "effect": "If unit's HP ≥ 50% in combat against a sword user, unit makes a follow-up attack and foe cannot.",
+      "name": "Drive Atk 2",
+      "effect": "Grants allies within 2 spaces Atk+3 during combat.",
       "exclusive": false,
-      "spCost": 200,
+      "spCost": 240,
       "movementRestriction": [
         ""
       ],
       "weaponRestriction": [
-        "Green Axe",
-        "Green Tome",
-        "Green Breath"
+        ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
     },
     {
       "name": "Threaten Atk 1",
@@ -43867,146 +43753,167 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Torrent Dance 1",
-      "effect": "If Sing or Dance is used, target also granted Res+3.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Triangle Adept 1",
-      "effect": "Gives Atk+10% if weapon-triangle advantage, Atk-10% if disadvantage.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Triangle Adept 2",
-      "effect": "Gives Atk+15% if weapon-triangle advantage, Atk-15% if disadvantage.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Triangle Adept 3",
-      "effect": "Gives Atk+20% if weapon-triangle advantage, Atk-20% if disadvantage.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Vantage 1",
-      "effect": "Unit counterattacks first when attacked at HP ≤ 25%.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Vantage 2",
-      "effect": "Unit counterattacks first when attacked at HP ≤ 50%.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Vantage 3",
-      "effect": "Unit counterattacks first when attacked at HP ≤ 75%.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Vengeful Fighter 1",
-      "effect": "If unit's HP ≥ 90% and foe initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Vengeful Fighter 2",
-      "effect": "If unit's HP ≥ 70% and foe initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
+      "name": "Drive Atk 1",
+      "effect": "Grants allies within 2 spaces Atk+2 during combat.",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
+        ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Vengeful Fighter 3",
-      "effect": "If unit's HP ≥ 50% and foe initiates combat, unit makes a guaranteed follow-up attack. Grants Special cooldown charge +1 per attack. (Does not stack.)",
+      "name": "Def Tactic 3",
+      "effect": "At start of turn, grants Def+6 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
       "exclusive": false,
       "spCost": 240,
       "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
+        ""
       ],
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Def Tactic 2",
+      "effect": "At start of turn, grants Def+4 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Def Tactic 1",
+      "effect": "At start of turn, grants Def+2 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Def Ploy 3",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Def-5 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Def Ploy 2",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Def-4 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Def Ploy 1",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Def-3 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Dagger Valor 3",
+      "effect": "If unit survives, all dagger users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Dagger Valor 2",
+      "effect": "If unit survives, all dagger users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Dagger Valor 1",
+      "effect": "If unit survives and uses a dagger, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
     },
     {
       "name": "Ward Armor",
@@ -44075,92 +43982,8 @@
       "type": "PASSIVE_C"
     },
     {
-      "name": "Warding Blow 1",
-      "effect": "Grants Res+2 during combat if unit initiates attack.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Warding Blow 2",
-      "effect": "Grants Res+4 during combat if unit initiates attack.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Warding Blow 3",
-      "effect": "Grants Res+6 during combat if unit initiates attack.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Warding Breath",
-      "effect": "Grants Res+4 during combat if unit is attacked. Also grants Special cooldown charge +1 per attack. (Does not stack. Only highest value applied.)",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Warding Stance 1",
-      "effect": "Grants Res+2 during combat when this unit is attacked.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Warding Stance 2",
-      "effect": "Grants Res+4 during combat when this unit is attacked.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Warding Stance 3",
-      "effect": "Grants Res+6 during combat when this unit is attacked.",
+      "name": "Breath of Life 3",
+      "effect": "If unit initiates attack, adjacent allies recover 7 HP after combat.",
       "exclusive": false,
       "spCost": 200,
       "movementRestriction": [
@@ -44169,82 +43992,11 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Warp Powder",
-      "effect": "If unit's HP ≥ 80%, unit can move adjacent to any ally within 2 spaces. (Skill cannot be inherited.)",
-      "exclusive": true,
-      "spCost": 300,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wary Fighter 1",
-      "effect": "Prevents follow-up attacks in combat from unit and foes if unit's HP ≥ 90%.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wary Fighter 2",
-      "effect": "Prevents follow-up attacks in combat from unit and foes if unit's HP ≥ 70%.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wary Fighter 3",
-      "effect": "Prevents follow-up attacks in combat from unit and foes if unit's HP ≥ 50%.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Infantry",
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Water Boost 1",
-      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Res+2 during combat.",
-      "exclusive": false,
-      "spCost": 50,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Water Boost 2",
-      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Res+4 during combat.",
+      "name": "Breath of Life 2",
+      "effect": "If unit initiates attack, adjacent allies recover 5 HP after combat.",
       "exclusive": false,
       "spCost": 100,
       "movementRestriction": [
@@ -44253,63 +44005,11 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Water Boost 3",
-      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Res+6 during combat.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Watersweep 1",
-      "effect": "If unit initiates attack, no follow-up occurs. Against foe with magic, staff or dragonstone, if unit’s Spd - foe’s Spd ≥ 5, foe can’t counterattack.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Watersweep 2",
-      "effect": "If unit initiates attack, no follow-up occurs. Against foe with magic, staff or dragonstone, if unit’s Spd - foe’s Spd ≥ 3, foe can’t counterattack.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Watersweep 3",
-      "effect": "If unit initiates attack, no follow-up occurs. Against foe with magic, staff or dragonstone, if unit’s Spd - foe’s Spd ≥ 1, foe can’t counterattack.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wind Boost 1",
-      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Spd+2 during combat.",
+      "name": "Breath of Life 1",
+      "effect": "If unit initiates attack, adjacent allies recover 3 HP after combat.",
       "exclusive": false,
       "spCost": 50,
       "movementRestriction": [
@@ -44318,195 +44018,11 @@
       "weaponRestriction": [
         ""
       ],
-      "type": "PASSIVE_A"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Wind Boost 2",
-      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Spd+4 during combat.",
-      "exclusive": false,
-      "spCost": 100,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Wind Boost 3",
-      "effect": "If unit has at least 3 more HP than enemy at the start of combat, unit receives Spd+6 during combat.",
-      "exclusive": false,
-      "spCost": 200,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_A"
-    },
-    {
-      "name": "Windsweep 1",
-      "effect": "If unit initiates attack, no follow-up occurs. Against foe with sword, lance, axe, bow, or dagger, if unit’s Spd - foe’s Spd ≥ 5, foe can’t counterattack.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Windsweep 2",
-      "effect": "If unit initiates attack, no follow-up occurs. Against foe with sword, lance, axe, bow, or dagger, if unit’s Spd - foe’s Spd ≥ 3, foe can’t counterattack.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Windsweep 3",
-      "effect": "If unit initiates attack, no follow-up occurs. Against foe with sword, lance, axe, bow, or dagger, if unit’s Spd - foe’s Spd ≥ 1, foe can’t counterattack.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wings of Mercy 1",
-      "effect": "Enables unit to warp adjacent to any ally with HP ≤ 30%.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wings of Mercy 2",
-      "effect": "Enables unit to warp adjacent to any ally with HP ≤ 40%.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wings of Mercy 3",
-      "effect": "Enables unit to warp adjacent to any ally with HP ≤ 50%.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        ""
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wrath 1",
-      "effect": "If unit's HP ≤ 25%, Special cooldown count-1 at start of turn if Special triggers by attacking. If Special triggers, +10 damage from Special.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wrath 2",
-      "effect": "If unit's HP ≤ 50%, Special cooldown count-1 at start of turn if Special triggers by attacking. If Special triggers, +10 damage from Special.",
-      "exclusive": false,
-      "spCost": 120,
-      "movementRestriction": [
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wrath 3",
-      "effect": "If unit's HP ≤ 75%, Special cooldown count-1 at start of turn if Special triggers by attacking. If Special triggers, +10 damage from Special.",
-      "exclusive": false,
-      "spCost": 240,
-      "movementRestriction": [
-        "Cavalry",
-        "Flying"
-      ],
-      "weaponRestriction": [
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Colorless Bow",
-        "Colorless Dagger",
-        "Colorless Staff"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wrathful Staff 1",
-      "effect": "If unit has 100% HP at the start of combat, damage from their staff will be calculated the same as other weapons.",
-      "exclusive": false,
-      "spCost": 60,
-      "movementRestriction": [
-        ""
-      ],
-      "weaponRestriction": [
-        "Red Sword",
-        "Blue Lance",
-        "Green Axe",
-        "Red Tome",
-        "Blue Tome",
-        "Green Tome",
-        "Red Breath",
-        "Blue Breath",
-        "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger"
-      ],
-      "type": "PASSIVE_B"
-    },
-    {
-      "name": "Wrathful Staff 2",
-      "effect": "If unit has ≥ 50% HP at the start of combat, damage from their staff will be calculated the same as other weapons.",
+      "name": "Bow Valor 3",
+      "effect": "If unit survives, all bow users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
       "exclusive": false,
       "spCost": 120,
       "movementRestriction": [
@@ -44522,16 +44038,17 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger"
+        "Colorless Breath",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
     },
     {
-      "name": "Wrathful Staff 3",
-      "effect": "Damage from unit's staff will be calculated the same as other weapons.",
+      "name": "Bow Valor 2",
+      "effect": "If unit survives, all bow users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
       "exclusive": false,
-      "spCost": 240,
+      "spCost": 60,
       "movementRestriction": [
         ""
       ],
@@ -44545,10 +44062,542 @@
         "Red Breath",
         "Blue Breath",
         "Green Breath",
-        "Colorless Bow",
-        "Colorless Dagger"
+        "Colorless Breath",
+        "Colorless Dagger",
+        "Colorless Staff"
       ],
-      "type": "PASSIVE_B"
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Bow Valor 1",
+      "effect": "If unit survives and uses a bow, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Bow Exp. 3",
+      "effect": "If unit survives, all bow users on team get 2x EXP. (If similar skill effects also used, only highest multiplier applies.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Bow Exp. 2",
+      "effect": "If unit survives, all bow users on team get 1.5x EXP. (If similar skill effects also used, only highest multiplier applies.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Bow Exp. 1",
+      "effect": "If unit survives and uses a bow, unit gets 1.5x EXP. (If similar skill effects also used, only highest multiplier applies.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "B Tome Valor 3",
+      "effect": "If unit survives, all blue tome users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "B Tome Valor 2",
+      "effect": "If unit survives, all blue tome users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "B Tome Valor 1",
+      "effect": "If unit survives and uses a blue tome, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "B Tome Exp. 3",
+      "effect": "If unit survives combat, all blue magic users on team get 2x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "B Tome Exp. 2",
+      "effect": "If unit survives combat, all blue magic users on team get 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "B Tome Exp. 1",
+      "effect": "If using blue magic and unit survives combat, unit gets 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Green Axe",
+        "Red Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Axe Valor 3",
+      "effect": "If unit survives, all axe users on team get 2x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Axe Valor 2",
+      "effect": "If unit survives, all axe users on team get 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Axe Valor 1",
+      "effect": "If unit survives and uses an axe, unit gets 1.5x SP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Axe Experience 3",
+      "effect": "If unit survives, all axe users on team get 2x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Axe Experience 2",
+      "effect": "If unit survives, all axe users on team get 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Axe Experience 1",
+      "effect": "If unit survives, unit gets 1.5x EXP. (If similar skill effects also used, only highest multiplier applied.)",
+      "exclusive": false,
+      "spCost": 30,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Red Sword",
+        "Blue Lance",
+        "Red Tome",
+        "Blue Tome",
+        "Green Tome",
+        "Red Breath",
+        "Blue Breath",
+        "Green Breath",
+        "Colorless Breath",
+        "Colorless Bow",
+        "Colorless Dagger",
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Tactic 3",
+      "effect": "At start of turn, grants Atk+6 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Tactic 2",
+      "effect": "At start of turn, grants Atk+4 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Tactic 1",
+      "effect": "At start of turn, grants Atk+2 to allies within 2 spaces for 1 turn. Granted only if number of that ally's movement type on current team ≤ 2.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Smoke 3",
+      "effect": "After combat, inflicts Atk-7 on foes within 2 spaces of target through their next actions.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Smoke 2",
+      "effect": "After combat, inflicts Atk-5 on foes within 2 spaces of target through their next actions.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Smoke 1",
+      "effect": "After combat, inflicts Atk-3 on foes within 2 spaces of target through their next actions.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        "Colorless Staff"
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Ploy 3",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Atk-5 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Ploy 2",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Atk-4 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 120,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Atk Ploy 1",
+      "effect": "At start of turn, all foes in cardinal directions with Res 1 or more lower than unit suffer Atk-3 until the end of foe's next action.",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        ""
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Armor March 3",
+      "effect": "If unit has an adjacent armored ally at the start of turn, unit and any such allies can move 1 extra space. (That turn only; does not stack.)",
+      "exclusive": false,
+      "spCost": 240,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
+    },
+    {
+      "name": "Armor March 1",
+      "effect": "If unit has 100% HP and an adjacent armored ally at start of turn, unit and any such allies can move 1 extra space. (That turn only; does not stack.)",
+      "exclusive": false,
+      "spCost": 60,
+      "movementRestriction": [
+        "Infantry",
+        "Cavalry",
+        "Flying"
+      ],
+      "weaponRestriction": [
+        ""
+      ],
+      "type": "PASSIVE_C"
     },
     {
       "name": "Armored Boots",


### PR DESCRIPTION
I finally got around to normalizing the dates to ISO 8601 format as well as fixing two Cargo table queries involving joins. The wiki seems to have stopped accepting fully qualified column names in the `group_by` clause.